### PR TITLE
generate node-based neighbor accessors, specific for each node

### DIFF
--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -528,7 +528,7 @@ def writeConstants(outputDir: JFile): JFile = {
         val specificNodeBasedAccessors = nodeTypes.map { nodeType =>
           val accessorName = camelCase(nodeType)
           val nodeClass = camelCaseCaps(nodeType)
-          s"def $accessorName: JIterator[$nodeClass] = get().$accessorName"
+          s"def _$accessorName: JIterator[$nodeClass] = get()._$accessorName"
         }
         specificNodeBasedAccessors + genericEdgeBasedAccessor
       }.mkString("\n")
@@ -562,7 +562,7 @@ def writeConstants(outputDir: JFile): JFile = {
         val specificNodeBasedAccessors = nodeTypes.map { nodeType =>
           val accessorName = camelCase(nodeType)
           val nodeClass = camelCaseCaps(nodeType)
-          s"def $accessorName: Iterator[$nodeClass] = createAdjacentNodeIteratorByOffSet($offsetPos).asScala.collect { case node: $nodeClass => node }"
+          s"def _$accessorName: Iterator[$nodeClass] = createAdjacentNodeIteratorByOffSet($offsetPos).asScala.collect { case node: $nodeClass => node }"
         }
         specificNodeBasedAccessors + genericEdgeBasedAccessor
       }.mkString("\n")

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -196,7 +196,7 @@ def writeConstants(outputDir: JFile): JFile = {
   }
 
   def neighborAccessorNameForEdge(edgeTypeName: String, direction: Direction.Value): String =
-    camelCase(edgeTypeName + "_" + direction)
+    "_" + camelCase(edgeTypeName + "_" + direction)
 
   def writeNodeFiles(outputDir: JFile): JFile = {
     val staticHeader =
@@ -514,7 +514,7 @@ def writeConstants(outputDir: JFile): JFile = {
             val neighborNodeInfos = inNodes.map { node =>
               createNeighborNodeInfo(camelCase(node), camelCaseCaps(node))
             }.toSet
-            NeighborInfo(neighborAccessorNameForEdge(s"_$edgeName", Direction.OUT), neighborNodeInfos, nextOffsetPos)
+            NeighborInfo(neighborAccessorNameForEdge(edgeName, Direction.OUT), neighborNodeInfos, nextOffsetPos)
           }
 
         val neighborInInfos =
@@ -522,7 +522,7 @@ def writeConstants(outputDir: JFile): JFile = {
             val neighborNodeInfos = outNodes.map { node =>
               createNeighborNodeInfo(camelCase(node.name), node.className)
             }
-            NeighborInfo(neighborAccessorNameForEdge(s"_$edgeName", Direction.IN), neighborNodeInfos, nextOffsetPos)
+            NeighborInfo(neighborAccessorNameForEdge(edgeName, Direction.IN), neighborNodeInfos, nextOffsetPos)
           }
 
         neighborOutInfos ++ neighborInInfos
@@ -562,10 +562,10 @@ def writeConstants(outputDir: JFile): JFile = {
 
       val neighborAccessors = neighborInfos.flatMap { case NeighborInfo(accessorNameForEdge, nodeInfos, offsetPos) =>
         val genericEdgeBasedAccessor =
-          s"override def $accessorNameForEdge : JIterator[StoredNode] = createAdjacentNodeIteratorByOffSet($offsetPos).asInstanceOf[JIterator[StoredNode]]"
+          s"override def $accessorNameForEdge: JIterator[StoredNode] = createAdjacentNodeIteratorByOffSet($offsetPos).asInstanceOf[JIterator[StoredNode]]"
 
-        val specificNodeBasedAccessors = nodeInfos.map { case NeighborNodeInfo(accessorName, className) =>
-          s"def $accessorName: Iterator[$className] = createAdjacentNodeIteratorByOffSet($offsetPos).asScala.collect { case node: $className => node }"
+        val specificNodeBasedAccessors = nodeInfos.map { case NeighborNodeInfo(accessorNameForNode, className) =>
+          s"def $accessorNameForNode: Iterator[$className] = $accessorNameForEdge.asScala.collect { case node: $className => node }"
         }
         specificNodeBasedAccessors + genericEdgeBasedAccessor
       }.mkString("\n")

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -223,7 +223,7 @@ def writeConstants(outputDir: JFile): JFile = {
         direction <- Direction.all
         edgeType <- schema.edgeTypes
         accessor = neighborAccessorNameForEdge(edgeType.name, direction)
-      } yield s"def _$accessor(): JIterator[StoredNode] = { JCollections.emptyIterator() }"
+      } yield s"def $accessor(): JIterator[StoredNode] = { JCollections.emptyIterator() }"
 
       val rootTypes =
         s"""$propertyErrorRegisterImpl

--- a/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -130,9 +130,11 @@ object Helpers {
        |}
        |""".stripMargin
 
-  /* obtained from repl via
-  :power
-  nme.keywords
+  /** obtained from repl via
+   * {{{
+   * :power
+   * nme.keywords
+   * }}}
    */
   val scalaReservedKeywords = Set(
     "abstract", ">:", "if", ".", "catch", "protected", "final", "super", "while", "true", "val", "do", "throw",

--- a/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -129,4 +129,15 @@ object Helpers {
        |  }
        |}
        |""".stripMargin
+
+  /* obtained from repl via
+  :power
+  nme.keywords
+   */
+  val scalaReservedKeywords = Set(
+    "abstract", ">:", "if", ".", "catch", "protected", "final", "super", "while", "true", "val", "do", "throw",
+    "<-", "package", "_", "macro", "@", "object", "false", "this", "then", "var", "trait", "with", "def", "else",
+    "class", "type", "#", "lazy", "null", "=", "<:", "override", "=>", "private", "sealed", "finally", "new",
+    "implicit", "extends", "for", "return", "case", "import", "forSome", ":", "yield", "try", "match", "<%")
+
 }

--- a/src/main/scala/overflowdb/codegen/Schema.scala
+++ b/src/main/scala/overflowdb/codegen/Schema.scala
@@ -112,7 +112,8 @@ case class NodeBaseTrait(name: String, hasKeys: List[String], `extends`: Option[
 
 case class InEdgeContext(edgeName: String, outNodes: Set[NodeType])
 
-case class NeighborInfo(accessorNameForEdge: String, nodeTypes: Set[String], offsetPosition: Int)
+case class NodeNeighborInfo(accessorName: String, className: String)
+case class NeighborInfo(accessorNameForEdge: String, nodeInfos: Set[NodeNeighborInfo], offsetPosition: Int)
 
 object HigherValueType extends Enumeration {
   type HigherValueType = Value

--- a/src/main/scala/overflowdb/codegen/Schema.scala
+++ b/src/main/scala/overflowdb/codegen/Schema.scala
@@ -112,7 +112,7 @@ case class NodeBaseTrait(name: String, hasKeys: List[String], `extends`: Option[
 
 case class InEdgeContext(edgeName: String, outNodes: Set[NodeType])
 
-case class NeighborInfo(accessorNameForEdge: String, neighborNodeTypes: Set[String], offsetPosition: Int)
+case class NeighborInfo(accessorNameForEdge: String, nodeTypes: Set[String], offsetPosition: Int)
 
 object HigherValueType extends Enumeration {
   type HigherValueType = Value

--- a/src/main/scala/overflowdb/codegen/Schema.scala
+++ b/src/main/scala/overflowdb/codegen/Schema.scala
@@ -112,7 +112,7 @@ case class NodeBaseTrait(name: String, hasKeys: List[String], `extends`: Option[
 
 case class InEdgeContext(edgeName: String, outNodes: Set[NodeType])
 
-case class NeighborInfo(accessorNameForEdge: String, neighborNodeType: String, offsetPosition: Int)
+case class NeighborInfo(accessorNameForEdge: String, neighborNodeTypes: Set[String], offsetPosition: Int)
 
 object HigherValueType extends Enumeration {
   type HigherValueType = Value

--- a/src/main/scala/overflowdb/codegen/Schema.scala
+++ b/src/main/scala/overflowdb/codegen/Schema.scala
@@ -111,7 +111,8 @@ case class NodeBaseTrait(name: String, hasKeys: List[String], `extends`: Option[
 }
 
 case class InEdgeContext(edgeName: String, outNodes: Set[NodeType])
-case class NeighborInfo(neighborAccessorName: String, neighborNodeType: String)
+
+case class NeighborInfo(accessorNameForEdge: String, neighborNodeType: String, offsetPosition: Int)
 
 object HigherValueType extends Enumeration {
   type HigherValueType = Value

--- a/src/main/scala/overflowdb/codegen/Schema.scala
+++ b/src/main/scala/overflowdb/codegen/Schema.scala
@@ -112,8 +112,8 @@ case class NodeBaseTrait(name: String, hasKeys: List[String], `extends`: Option[
 
 case class InEdgeContext(edgeName: String, outNodes: Set[NodeType])
 
-case class NodeNeighborInfo(accessorName: String, className: String)
-case class NeighborInfo(accessorNameForEdge: String, nodeInfos: Set[NodeNeighborInfo], offsetPosition: Int)
+case class NeighborNodeInfo(accessorName: String, className: String)
+case class NeighborInfo(accessorNameForEdge: String, nodeInfos: Set[NeighborNodeInfo], offsetPosition: Int)
 
 object HigherValueType extends Enumeration {
   type HigherValueType = Value


### PR DESCRIPTION
This PR removes the (non `_`-prefixed) node-specific accessors.
It adds node-specific accessors for each neighbouring node type. 
The generic neighbor accessors (which are defined in StoredNode) are unchanged. 

To illustrate, take the following node definition:
```
node: A, outEdges: [ {name:AST, inNodes: [B,C]}]
```
Simplified diff in generated code:
Old:
```scala
class A {
  override def _astOut: JIterator[StoredNode] = ???
  def astOut: JIterator[StoredNode] = ??? // removed by this PR
}
```
New:
```scala
class A {
  override def _astOut: JIterator[StoredNode] = ??? //unchanged
  def _bViaAstOut: Iterator[B] = _astOut.asScala.collect { case node: B => node }
  def _cViaAstOut: Iterator[C] = _astOut.asScala.collect { case node: C => node }
}
```

Those neighbor accessors are defined for both OUT and IN nodes (the schema only defines the OUT nodes, the IN connections are computed).

Note: I initially only appended `Via$EdgeAndDirection` if there were multiple occurrences of the same neighbor node, but then decided to go for less magic and more explicitness. 

Defining cardinalities will be a follow-up PR, for now everything is an Iterator.

Related: https://github.com/ShiftLeftSecurity/codepropertygraph/pull/567, https://github.com/ShiftLeftSecurity/codescience/pull/3469