### PR TITLE
allow to set cardinalities between nodes (both ways)

### DIFF
--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -529,7 +529,8 @@ def writeConstants(outputDir: JFile): JFile = {
             val viaEdgeAndDirection = camelCase(edgeName) + "In"
             val neighborNodeInfos = neighborNodes.map { neighborNode =>
               // TODO cardinality for IN node - need to hold in InEdgeContext?
-              createNeighborNodeInfo(neighborNode.name, neighborNode.className, viaEdgeAndDirection, Cardinality.List)
+              val neighborNodeClassName = schema.nodeTypeByName(neighborNode).className
+              createNeighborNodeInfo(neighborNode.name, neighborNodeClassName, viaEdgeAndDirection, Cardinality.List)
             }
             NeighborInfo(neighborAccessorNameForEdge(edgeName, Direction.IN), neighborNodeInfos, nextOffsetPos)
           }

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -530,7 +530,7 @@ def writeConstants(outputDir: JFile): JFile = {
             val neighborNodeInfos = neighborNodes.map { neighborNode =>
               // TODO cardinality for IN node - need to hold in InEdgeContext?
               val neighborNodeClassName = schema.nodeTypeByName(neighborNode).className
-              createNeighborNodeInfo(neighborNode.name, neighborNodeClassName, viaEdgeAndDirection, Cardinality.List)
+              createNeighborNodeInfo(neighborNode, neighborNodeClassName, viaEdgeAndDirection, Cardinality.List)
             }
             NeighborInfo(neighborAccessorNameForEdge(edgeName, Direction.IN), neighborNodeInfos, nextOffsetPos)
           }

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -525,11 +525,11 @@ def writeConstants(outputDir: JFile): JFile = {
           }
 
         val neighborInInfos =
-          inEdges.map { case InEdgeContext(edgeName, outNodes) =>
+          inEdges.map { case InEdgeContext(edgeName, neighborNodes) =>
             val viaEdgeAndDirection = camelCase(edgeName) + "In"
-            val neighborNodeInfos = outNodes.map { node =>
+            val neighborNodeInfos = neighborNodes.map { neighborNode =>
               // TODO cardinality for IN node - need to hold in InEdgeContext?
-              createNeighborNodeInfo(node.name, node.className, viaEdgeAndDirection, Cardinality.List)
+              createNeighborNodeInfo(neighborNode.name, neighborNode.className, viaEdgeAndDirection, Cardinality.List)
             }
             NeighborInfo(neighborAccessorNameForEdge(edgeName, Direction.IN), neighborNodeInfos, nextOffsetPos)
           }

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -323,7 +323,7 @@ def writeConstants(outputDir: JFile): JFile = {
       }.mkString(",\n")
 
       val outEdgeNames: Seq[String] = nodeType.outEdges.map(_.edgeName)
-      val inEdgeNames:  Seq[String] = schema.nodeToInEdgeContexts.getOrElse(nodeType, Seq.empty).map(_.edgeName)
+      val inEdgeNames:  Seq[String] = schema.nodeToInEdgeContexts.getOrElse(nodeType.name, Seq.empty).map(_.edgeName)
 
       val outEdgeLayouts = outEdgeNames.map(edge => s"edges.${camelCaseCaps(edge)}.layoutInformation").mkString(", ")
       val inEdgeLayouts = inEdgeNames.map(edge => s"edges.${camelCaseCaps(edge)}.layoutInformation").mkString(", ")
@@ -502,7 +502,7 @@ def writeConstants(outputDir: JFile): JFile = {
         var offsetPos = -1
         def nextOffsetPos = { offsetPos += 1; offsetPos }
 
-        val inEdges = schema.nodeToInEdgeContexts.getOrElse(nodeType, Nil)
+        val inEdges = schema.nodeToInEdgeContexts.getOrElse(nodeType.name, Nil)
 
         def createNeighborNodeInfo(nodeName: String, neighborClassName: String, edgeAndDirection: String, cardinality: Cardinality) = {
           val accessorName = s"_${camelCase(nodeName)}Via${edgeAndDirection.capitalize}"

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -502,23 +502,24 @@ def writeConstants(outputDir: JFile): JFile = {
         var offsetPos = -1
         def nextOffsetPos = { offsetPos += 1; offsetPos }
 
-        def escapeIfKeyword(value: String) =
-          if (scalaReservedKeywords.contains(value)) s"`$value`"
-          else value
-
         val inEdges = schema.nodeToInEdgeContexts.getOrElse(nodeType, Nil)
 
-        def createNeighborNodeInfo(nodeName: String, neighborClassName: String, edgeAndDirection: String) = {
+        def createNeighborNodeInfo(nodeName: String, neighborClassName: String, edgeAndDirection: String, cardinality: Cardinality) = {
           val accessorName = s"_${camelCase(nodeName)}Via${edgeAndDirection.capitalize}"
-          NeighborNodeInfo(escapeIfKeyword(accessorName), neighborClassName)
+          NeighborNodeInfo(Helpers.escapeIfKeyword(accessorName), neighborClassName, cardinality)
         }
 
         val neighborOutInfos =
           nodeType.outEdges.map { case OutEdgeEntry(edgeName, inNodes) =>
             val viaEdgeAndDirection = camelCase(edgeName) + "Out"
-            val neighborNodeInfos = inNodes.map { node =>
-              val nodeName = node.name
-              createNeighborNodeInfo(nodeName, camelCaseCaps(nodeName), viaEdgeAndDirection)
+            val neighborNodeInfos = inNodes.map { inNode =>
+              val nodeName = inNode.name
+              val cardinality = inNode.cardinality.getOrElse("n:n") match {
+                case c if c.endsWith(":1") => Cardinality.One
+                case c if c.endsWith(":0-1") => Cardinality.ZeroOrOne
+                case c if c.endsWith(":n") => Cardinality.List
+              }
+              createNeighborNodeInfo(nodeName, camelCaseCaps(nodeName), viaEdgeAndDirection, cardinality)
             }.toSet
             NeighborInfo(neighborAccessorNameForEdge(edgeName, Direction.OUT), neighborNodeInfos, nextOffsetPos)
           }
@@ -527,7 +528,8 @@ def writeConstants(outputDir: JFile): JFile = {
           inEdges.map { case InEdgeContext(edgeName, outNodes) =>
             val viaEdgeAndDirection = camelCase(edgeName) + "In"
             val neighborNodeInfos = outNodes.map { node =>
-              createNeighborNodeInfo(node.name, node.className, viaEdgeAndDirection)
+              // TODO cardinality for IN node - need to hold in InEdgeContext?
+              createNeighborNodeInfo(node.name, node.className, viaEdgeAndDirection, Cardinality.List)
             }
             NeighborInfo(neighborAccessorNameForEdge(edgeName, Direction.IN), neighborNodeInfos, nextOffsetPos)
           }
@@ -536,13 +538,18 @@ def writeConstants(outputDir: JFile): JFile = {
       }
 
       val neighborDelegators = neighborInfos.flatMap { case NeighborInfo(accessorNameForEdge, nodeInfos, _) =>
-        val genericEdgeBasedAccessor =
+        val genericEdgeBasedDelegators =
           s"override def $accessorNameForEdge(): JIterator[StoredNode] = get().$accessorNameForEdge"
 
-        val specificNodeBasedAccessors = nodeInfos.map { case NeighborNodeInfo(accessorName, className) =>
-          s"def $accessorName: Iterator[$className] = get().$accessorName"
+        val specificNodeBasedDelegators = nodeInfos.map { case NeighborNodeInfo(accessorNameForNode, className, cardinality) =>
+          val returnType = cardinality match {
+            case Cardinality.List => s"Iterator[$className]"
+            case Cardinality.ZeroOrOne => s"Option[$className]"
+            case Cardinality.One => s"$className"
+          }
+          s"def $accessorNameForNode: $returnType = get().$accessorNameForNode"
         }
-        specificNodeBasedAccessors + genericEdgeBasedAccessor
+        specificNodeBasedDelegators + genericEdgeBasedDelegators
       }.mkString("\n")
 
       val nodeRefImpl = {
@@ -571,8 +578,15 @@ def writeConstants(outputDir: JFile): JFile = {
         val genericEdgeBasedAccessor =
           s"override def $accessorNameForEdge: JIterator[StoredNode] = createAdjacentNodeIteratorByOffSet($offsetPos).asInstanceOf[JIterator[StoredNode]]"
 
-        val specificNodeBasedAccessors = nodeInfos.map { case NeighborNodeInfo(accessorNameForNode, className) =>
-          s"def $accessorNameForNode: Iterator[$className] = $accessorNameForEdge.asScala.collect { case node: $className => node }"
+        val specificNodeBasedAccessors = nodeInfos.map { case NeighborNodeInfo(accessorNameForNode, className, cardinality) =>
+          cardinality match {
+            case Cardinality.List =>
+              s"def $accessorNameForNode: Iterator[$className] = $accessorNameForEdge.asScala.collect { case node: $className => node }"
+            case Cardinality.ZeroOrOne =>
+              s"def $accessorNameForNode: Option[$className] = $accessorNameForEdge.asScala.collect { case node: $className => node }.nextOption"
+            case Cardinality.One =>
+              s"def $accessorNameForNode: $className = $accessorNameForEdge.asScala.collect { case node: $className => node }.next"
+          }
         }
         specificNodeBasedAccessors + genericEdgeBasedAccessor
       }.mkString("\n")

--- a/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -142,4 +142,8 @@ object Helpers {
     "class", "type", "#", "lazy", "null", "=", "<:", "override", "=>", "private", "sealed", "finally", "new",
     "implicit", "extends", "for", "return", "case", "import", "forSome", ":", "yield", "try", "match", "<%")
 
+  def escapeIfKeyword(value: String) =
+    if (scalaReservedKeywords.contains(value)) s"`$value`"
+    else value
+
 }

--- a/src/main/scala/overflowdb/codegen/Schema.scala
+++ b/src/main/scala/overflowdb/codegen/Schema.scala
@@ -40,7 +40,7 @@ class Schema(schemaFile: String) {
       } yield (inNode.get, outEdge.edgeName, nodeType)
 
     /* grouping above (node, inEdge, adjacentNode) tuples by `node` and `inEdge`
-     * TODO use scala 2.13's `groupMap` */
+     * we use this from sbt, so unfortunately we can't yet use scala 2.13's `groupMap` :( */
     val grouped: Map[NodeType, Map[String, Seq[NodeType]]] =
       tuples.groupBy(_._1).mapValues(_.groupBy(_._2).mapValues(_.map(_._3)).toMap)
 
@@ -115,7 +115,7 @@ case class NodeBaseTrait(name: String, hasKeys: List[String], `extends`: Option[
 
 case class InEdgeContext(edgeName: String, outNodes: Set[NodeType])
 
-case class NeighborNodeInfo(accessorName: String, className: String)
+case class NeighborNodeInfo(accessorName: String, className: String, cardinality: Cardinality)
 case class NeighborInfo(accessorNameForEdge: String, nodeInfos: Set[NeighborNodeInfo], offsetPosition: Int)
 
 object HigherValueType extends Enumeration {


### PR DESCRIPTION
| A.outEdge(inNode=B) cardinality | A.b type    | B.a type    |
| ------------------------------- | ------------| ------------|
| `1:1`                           | `B`         | `A`         | 
| `1:0-1`                         | `Option[B]` | `A`         |
| `0-1:1`                         | `B`         | `Option[A]` |
| `1:n`                           | `List[B]`   | `A`         |
| `n:1`                           | `B`         | `List[A]`   |
| `0-1:n`                         | `List[B]`   | `Option[A]` |
| `n:0-1`                         | `Option[B]` | `List[A]`   |

re https://github.com/ShiftLeftSecurity/codepropertygraph/pull/567