### PR TITLE
adaptations for new odb public api

### DIFF
--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -251,7 +251,7 @@ def writeConstants(outputDir: JFile): JFile = {
            |trait CpgNode
            |
            |/* a node that stored inside an OdbGraph (rather than e.g. DiffGraph) */
-           |trait StoredNode extends Vertex with CpgNode with OdbElement with Product {
+           |trait StoredNode extends Vertex with CpgNode with overflowdb.Node with Product {
            |  /* underlying vertex in the graph database.
            |   * since this is a StoredNode, this is always set */
            |  def underlying: Vertex = this
@@ -264,6 +264,8 @@ def writeConstants(outputDir: JFile): JFile = {
            |  // Java does not seem to be capable of calling methods from java classes if a scala trait is in the inheritance
            |  // chain.
            |  protected def getId: JLong = underlying.id.asInstanceOf[JLong]
+           |
+           |  override def id2: Long = underlying.id.asInstanceOf[Long]
            |
            |  /* all properties plus label and id */
            |  def toMap: Map[String, Any] = {

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -256,8 +256,6 @@ def writeConstants(outputDir: JFile): JFile = {
            |   * since this is a StoredNode, this is always set */
            |  def underlying: Vertex = this
            |
-           |  def asNodeRef: NodeRef[_] = this.asInstanceOf[NodeRef[_]]
-           |
            |  /** labels of product elements, used e.g. for pretty-printing */
            |  def productElementLabel(n: Int): String
            |

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -263,7 +263,7 @@ def writeConstants(outputDir: JFile): JFile = {
            |
            |  // Java does not seem to be capable of calling methods from java classes if a scala trait is in the inheritance
            |  // chain.
-           |  override def getId: JLong = underlying.id.asInstanceOf[JLong]
+           |  protected def getId: JLong = underlying.id.asInstanceOf[JLong]
            |
            |  /* all properties plus label and id */
            |  def toMap: Map[String, Any] = {
@@ -460,7 +460,8 @@ def writeConstants(outputDir: JFile): JFile = {
       val productElements: List[ProductElement] = {
         var currIndex = -1
         def nextIdx = { currIndex += 1; currIndex }
-        val forId = ProductElement("id", "getId", nextIdx)
+//        val forId = ProductElement("id", "getId", nextIdx)
+        val forId = ProductElement("id", "-1", nextIdx)
         val forKeys = keys.map { key =>
           val name = camelCase(key.name)
           ProductElement(name, name, nextIdx)
@@ -495,7 +496,6 @@ def writeConstants(outputDir: JFile): JFile = {
       val nodeBaseImpl =
         s"""trait ${className}Base extends Node $mixinTraitsForBase $propertyBasedTraits {
            |  def asStored : StoredNode = this.asInstanceOf[StoredNode]
-           |  override def getId: JLong = -1L
            |
            |  $abstractContainedNodeAccessors
            |
@@ -622,7 +622,6 @@ def writeConstants(outputDir: JFile): JFile = {
            |  $mixinTraits with ${className}Base {
            |
            |  override def layoutInformation: NodeLayoutInformation = $className.layoutInformation
-           |  override def getId = ref.id
            |
            |  /* all properties */
            |  override def valueMap: JMap[String, AnyRef] = $valueMapImpl

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -248,10 +248,10 @@ def writeConstants(outputDir: JFile): JFile = {
       val rootTypes =
         s"""$propertyErrorRegisterImpl
            |
-           |trait Node
+           |trait CpgNode
            |
            |/* a node that stored inside an OdbGraph (rather than e.g. DiffGraph) */
-           |trait StoredNode extends Vertex with Node with OdbElement with Product {
+           |trait StoredNode extends Vertex with CpgNode with OdbElement with Product {
            |  /* underlying vertex in the graph database.
            |   * since this is a StoredNode, this is always set */
            |  def underlying: Vertex = this
@@ -299,7 +299,7 @@ def writeConstants(outputDir: JFile): JFile = {
             s"with ${camelCaseCaps(traitName)}Base"
           }.mkString(" ")
 
-        s"""trait ${nodeBaseTrait.className}Base extends Node $mixins $mixinTraitsForBase
+        s"""trait ${nodeBaseTrait.className}Base extends CpgNode $mixins $mixinTraitsForBase
            |trait ${nodeBaseTrait.className} extends StoredNode with ${nodeBaseTrait.className}Base $mixinTraits
            |""".stripMargin
       }.mkString("\n")
@@ -494,7 +494,7 @@ def writeConstants(outputDir: JFile): JFile = {
       }.mkString("\n")
 
       val nodeBaseImpl =
-        s"""trait ${className}Base extends Node $mixinTraitsForBase $propertyBasedTraits {
+        s"""trait ${className}Base extends CpgNode $mixinTraitsForBase $propertyBasedTraits {
            |  def asStored : StoredNode = this.asInstanceOf[StoredNode]
            |
            |  $abstractContainedNodeAccessors
@@ -710,7 +710,7 @@ def writeConstants(outputDir: JFile): JFile = {
          |import java.util.{Map => JMap, Set => JSet}
          |
          |/** base type for all nodes that can be added to a graph, e.g. the diffgraph */
-         |trait NewNode extends Node {
+         |trait NewNode extends CpgNode {
          |  def label: String
          |  def properties: Map[String, Any]
          |  def containedNodesByLocalName: Map[String, List[Node]]

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -462,8 +462,7 @@ def writeConstants(outputDir: JFile): JFile = {
       val productElements: List[ProductElement] = {
         var currIndex = -1
         def nextIdx = { currIndex += 1; currIndex }
-//        val forId = ProductElement("id", "getId", nextIdx)
-        val forId = ProductElement("id", "-1", nextIdx)
+        val forId = ProductElement("id", "id2", nextIdx)
         val forKeys = keys.map { key =>
           val name = camelCase(key.name)
           ProductElement(name, name, nextIdx)

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -229,7 +229,7 @@ def writeConstants(outputDir: JFile): JFile = {
          |import java.util.{Collections => JCollections, HashMap => JHashMap, Iterator => JIterator, Map => JMap, Set => JSet}
          |import org.apache.tinkerpop.gremlin.structure.{Direction, Vertex, VertexProperty}
          |import overflowdb.{EdgeFactory, NodeFactory, NodeLayoutInformation, OdbElement, OdbNode, OdbGraph, OdbNodeProperty, NodeRef, PropertyKey}
-         |import overflowdb.traversal.{NodeRefOps, Traversal}
+         |import overflowdb.traversal.Traversal
          |import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils
          |import scala.jdk.CollectionConverters._
          |""".stripMargin

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -261,6 +261,8 @@ def writeConstants(outputDir: JFile): JFile = {
            |   * since this is a StoredNode, this is always set */
            |  def underlying: Vertex = this
            |
+           |  def asNodeRef: NodeRef[_] = this.asInstanceOf[NodeRef[_]]
+           |
            |  // Java does not seem to be capable of calling methods from java classes if a scala trait is in the inheritance
            |  // chain.
            |  protected def getId: JLong = underlying.id.asInstanceOf[JLong]

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -248,18 +248,18 @@ def writeConstants(outputDir: JFile): JFile = {
       val rootTypes =
         s"""$propertyErrorRegisterImpl
            |
-           |trait Node extends Product {
-           |  /** labels of product elements, used e.g. for pretty-printing */
-           |  def productElementLabel(n: Int): String
-           |}
+           |trait Node
            |
            |/* a node that stored inside an OdbGraph (rather than e.g. DiffGraph) */
-           |trait StoredNode extends Vertex with Node with OdbElement {
+           |trait StoredNode extends Vertex with Node with OdbElement with Product {
            |  /* underlying vertex in the graph database.
            |   * since this is a StoredNode, this is always set */
            |  def underlying: Vertex = this
            |
            |  def asNodeRef: NodeRef[_] = this.asInstanceOf[NodeRef[_]]
+           |
+           |  /** labels of product elements, used e.g. for pretty-printing */
+           |  def productElementLabel(n: Int): String
            |
            |  // Java does not seem to be capable of calling methods from java classes if a scala trait is in the inheritance
            |  // chain.
@@ -498,19 +498,6 @@ def writeConstants(outputDir: JFile): JFile = {
            |  def asStored : StoredNode = this.asInstanceOf[StoredNode]
            |
            |  $abstractContainedNodeAccessors
-           |
-           |  override def productElementLabel(n: Int): String =
-           |      n match {
-           |        $productElementLabels
-           |      }
-           |
-           |  override def productElement(n: Int): Any =
-           |      n match {
-           |        $productElementAccessors
-           |      }
-           |
-           |  override def productPrefix = "$className"
-           |  override def productArity = ${productElements.size}
            |}
            |""".stripMargin
 
@@ -596,6 +583,19 @@ def writeConstants(outputDir: JFile): JFile = {
            |  override def label: String = {
            |    $className.Label
            |  }
+           |
+           |  override def productElementLabel(n: Int): String =
+           |    n match {
+           |      $productElementLabels
+           |    }
+           |
+           |  override def productElement(n: Int): Any =
+           |    n match {
+           |      $productElementAccessors
+           |    }
+           |
+           |  override def productPrefix = "$className"
+           |  override def productArity = ${productElements.size}
            |}
            |""".stripMargin
       }
@@ -632,6 +632,19 @@ def writeConstants(outputDir: JFile): JFile = {
            |  override def label: String = {
            |    $className.Label
            |  }
+           |
+           |  override def productElementLabel(n: Int): String =
+           |    n match {
+           |      $productElementLabels
+           |    }
+           |
+           |  override def productElement(n: Int): Any =
+           |    n match {
+           |      $productElementAccessors
+           |    }
+           |
+           |  override def productPrefix = "$className"
+           |  override def productArity = ${productElements.size}
            |
            |  override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[$classNameDb]
            |

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -248,7 +248,9 @@ def writeConstants(outputDir: JFile): JFile = {
       val rootTypes =
         s"""$propertyErrorRegisterImpl
            |
-           |trait CpgNode
+           |trait CpgNode {
+           |  def label: String
+           |}
            |
            |/* a node that stored inside an OdbGraph (rather than e.g. DiffGraph) */
            |trait StoredNode extends Vertex with CpgNode with overflowdb.Node with Product {
@@ -713,7 +715,6 @@ def writeConstants(outputDir: JFile): JFile = {
          |
          |/** base type for all nodes that can be added to a graph, e.g. the diffgraph */
          |trait NewNode extends CpgNode {
-         |  def label: String
          |  def properties: Map[String, Any]
          |  def containedNodesByLocalName: Map[String, List[${DefaultNodeTypes.NodeClassname}]]
          |  def allContainedNodes: List[${DefaultNodeTypes.NodeClassname}] = containedNodesByLocalName.values.flatten.toList

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -250,7 +250,6 @@ def writeConstants(outputDir: JFile): JFile = {
            |
            |trait Node extends Product {
            |  def label: String
-           |  def getId: JLong
            |
            |  /** labels of product elements, used e.g. for pretty-printing */
            |  def productElementLabel(n: Int): String

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -249,8 +249,6 @@ def writeConstants(outputDir: JFile): JFile = {
         s"""$propertyErrorRegisterImpl
            |
            |trait Node extends Product {
-           |  def label: String
-           |
            |  /** labels of product elements, used e.g. for pretty-printing */
            |  def productElementLabel(n: Int): String
            |}
@@ -700,7 +698,7 @@ def writeConstants(outputDir: JFile): JFile = {
          |
          |/** base type for all nodes that can be added to a graph, e.g. the diffgraph */
          |trait NewNode extends Node {
-         |  override def label: String
+         |  def label: String
          |  def properties: Map[String, Any]
          |  def containedNodesByLocalName: Map[String, List[Node]]
          |  def allContainedNodes: List[Node] = containedNodesByLocalName.values.flatten.toList

--- a/src/main/scala/overflowdb/codegen/Schema.scala
+++ b/src/main/scala/overflowdb/codegen/Schema.scala
@@ -134,7 +134,8 @@ object Direction extends Enumeration {
 
 object DefaultNodeTypes {
   /** root type for all nodes */
-  val Node = "NODE"
+  val Node = "CPG_NODE"
+  val NodeClassname = "CpgNode"
 }
 
 object DefaultEdgeTypes {

--- a/src/main/scala/overflowdb/codegen/SchemaMerger.scala
+++ b/src/main/scala/overflowdb/codegen/SchemaMerger.scala
@@ -58,7 +58,7 @@ object SchemaMerger {
         val outEdgeNames = outEdges.map(_.obj("edgeName").str).toSet
 
         if (!outEdgeNames.contains("CONTAINS_NODE")) {
-          val containsNodeEntry = read(""" { "edgeName": "CONTAINS_NODE", "inNodes": [{"name": "NODE"}] }""")
+          val containsNodeEntry = read(s""" { "edgeName": "CONTAINS_NODE", "inNodes": [{"name": "${DefaultNodeTypes.Node}"}] }""")
           outEdges.append(containsNodeEntry)
         }
 

--- a/src/test/scala/overflowdb/codegen/SchemaMergerTest.scala
+++ b/src/test/scala/overflowdb/codegen/SchemaMergerTest.scala
@@ -61,7 +61,7 @@ class SchemaMergerTest extends WordSpec with Matchers {
               {"name": "ANNOTATION"}
             ] },
             { "edgeName": "ALIAS_OF","inNodes": [{"name": "TYPE"}] } ,
-            { "edgeName": "CONTAINS_NODE","inNodes":[{"name": "NODE"}]}
+            { "edgeName": "CONTAINS_NODE","inNodes":[{"name": "CPG_NODE"}]}
            ]}]}""")
     }
   }
@@ -102,7 +102,7 @@ class SchemaMergerTest extends WordSpec with Matchers {
              "name":"CALL_SITE",
              "outEdges": [
                { "edgeName": "SOME_EDGE", "inNodes": [ {"name": "SOME_OTHER_NODE"} ] },
-               { "edgeName": "CONTAINS_NODE", "inNodes": [{ "name": "NODE" }] }
+               { "edgeName": "CONTAINS_NODE", "inNodes": [{ "name": "CPG_NODE" }] }
              ]
            }
          ]}""")
@@ -129,9 +129,9 @@ class SchemaMergerTest extends WordSpec with Matchers {
              "outEdges": [
                { "edgeName": "SOME_EDGE", "inNodes": [ {"name": "SOME_OTHER_NODE" }] },
                { "edgeName": "CONTAINS_NODE", "inNodes": [
-                 {"name": "NODE"},
                  {"name": "CALL"},
-                 {"name": "METHOD"}
+                 {"name": "METHOD"},
+                 {"name": "CPG_NODE"}
                ] }
              ]
            }
@@ -169,7 +169,7 @@ class SchemaMergerTest extends WordSpec with Matchers {
                {"name": "NODE_C", "cardinality":"1:1"},
                {"name": "NODE_B"}
              ]},
-             { "edgeName": "CONTAINS_NODE", "inNodes": [{ "name": "NODE" }] }
+             { "edgeName": "CONTAINS_NODE", "inNodes": [{ "name": "CPG_NODE" }] }
            ]
          }
        ]}""")
@@ -204,7 +204,7 @@ class SchemaMergerTest extends WordSpec with Matchers {
              { "edgeName": "SOME_EDGE", "inNodes": [
                {"name": "NODE_B", "cardinality":"n:n"}
              ]},
-             { "edgeName": "CONTAINS_NODE", "inNodes": [{ "name": "NODE" }] }
+             { "edgeName": "CONTAINS_NODE", "inNodes": [{ "name": "CPG_NODE" }] }
            ]
          }
        ]}""")


### PR DESCRIPTION
* all CpgNodes have a `label`
* RIP asNodeRef
* make StoredNode extend overflowdb.Node
* stop generating specific accessors for `Node` root type
* rename Node -> CpgNode
* move `Product` trait to StoredNode
* drop label from Node
* StoredNode.asNodeRef
* drop `Node.getId` - now covered by OdbNode.id2