### PR TITLE
Default value for `boolean` in `NewNodes`

### DIFF
--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -728,6 +728,7 @@ def writeConstants(outputDir: JFile): JFile = {
             if (getHigherType(key) == HigherValueType.Option) " = None"
             else if (key.valueType == "int") " = -1"
             else if (getHigherType(key) == HigherValueType.None && key.valueType == "string") """ ="" """
+	    else if (getHigherType(key) == HigherValueType.None && key.valueType == "boolean") """ =false """
             else if (getHigherType(key) == HigherValueType.List) "= List()"
             else ""
           s"${camelCase(key.name)}: ${getCompleteType(key)} $optionalDefault"


### PR DESCRIPTION
For all string and integer properties of NewNodes, we assume a default of "" and 0 respectively, however, we forgot to specify a default value of false for booleans. This PR resolves this.