### PR TITLE
restore APPEND behavior of setting LIST-valued property with single element

### DIFF
--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -694,7 +694,7 @@ def writeConstants(outputDir: JFile): JFile = {
               case Cardinality.List =>
                 s"""value match {
                    |    case null | None => Nil
-                   |    case someVal:${getBaseType(key)} => List(someVal)
+                   |    case someVal:${getBaseType(key)} => this._${camelCase(key.name)} :+ someVal // todo: deprecate
                    |    case jCollection: java.lang.Iterable[_] => jCollection.asInstanceOf[java.util.Collection[${getBaseType(key)}]].iterator.asScala.toList
                    |    case lst: List[_] => value.asInstanceOf[List[${getBaseType(key)}]]
                    |  }""".stripMargin
@@ -716,7 +716,7 @@ def writeConstants(outputDir: JFile): JFile = {
               case Cardinality.List =>
                 s"""value match {
                    |    case null | None => Nil
-                   |    case someVal:${containedNode.nodeTypeClassName} => List(someVal)
+                   |    case someVal:${containedNode.nodeTypeClassName} => this._${containedNode.localName} :+ someVal // todo: deprecate
                    |    case jCollection: java.lang.Iterable[_] => jCollection.asInstanceOf[java.util.Collection[${containedNode.nodeTypeClassName}]].iterator.asScala.toList
                    |    case lst: List[_] => value.asInstanceOf[List[${containedNode.nodeTypeClassName}]]
                    |  }""".stripMargin


### PR DESCRIPTION
Theoretically, this O(N^2) pattern is mostly deprecated. In practice, I missed at least one use. So let's restore this for now, and maybe deprecate in the future (unused code-paths are not that expensive).