### PR TITLE
generate node-specific traversal extensions for property filters

### DIFF
--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -256,7 +256,7 @@ class CodeGen(schemaFile: String, basePackage: String) {
          |  def label: String
          |}
          |
-         |/* a node that stored inside an Graph (rather than e.g. DiffGraph) */
+         |/* A node that is stored inside an Graph (rather than e.g. DiffGraph) */
          |trait StoredNode extends Node with CpgNode with Product {
          |  /* underlying Node in the graph.
          |   * since this is a StoredNode, this is always set */

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -313,8 +313,7 @@ class CodeGen(schemaFile: String, basePackage: String) {
           case Cardinality.ZeroOrOne | Cardinality.List => "flatMap"
         }
 
-        s"""
-           |  /** Traverse to $name property */
+        s"""  /** Traverse to $name property */
            |  def $name: Traversal[$baseType] =
            |    traversal.$mapOrFlatMap(_.$name)
            |
@@ -388,11 +387,16 @@ class CodeGen(schemaFile: String, basePackage: String) {
           s"with ${camelCaseCaps(traitName)}Base"
         }.mkString(" ")
 
-      s"""$staticHeader
+      s"""package $nodesPackage
          |
-         |trait ${className}Base extends CpgNode $mixins $mixinTraitsForBase
+         |import overflowdb.traversal.Traversal
          |
-         |trait $className extends StoredNode with ${className}Base $mixinTraits
+         |trait ${className}Base extends CpgNode 
+         |$mixins 
+         |$mixinTraitsForBase
+         |
+         |trait $className extends StoredNode with ${className}Base 
+         |$mixinTraits
          |
          |${generatePropertyTraversals(className, properties)}
          |

--- a/src/main/scala/overflowdb/codegen/Schema.scala
+++ b/src/main/scala/overflowdb/codegen/Schema.scala
@@ -23,6 +23,9 @@ class Schema(schemaFile: String) {
   lazy val nodeTypeByName: Map[String, NodeType] =
     nodeTypes.map(node => node.name -> node).toMap
 
+  lazy val nodeBaseTypeByName: Map[String, NodeBaseTrait] =
+    nodeBaseTraits.map(node => node.name -> node).toMap
+
   lazy val nodePropertyByName: Map[String, Property] =
     nodeKeys.map(property => property.name -> property).toMap
 


### PR DESCRIPTION
* generate specific accessors based on types (bool, int, string)
* for both NodeTypes (e.g. Method) and NodeBaseTypes (e.g. Expression)
* some refactorings, e.g. split generated code into more files, and moving things out of node package object for java compat