### PR TITLE
Added ID to NewNodeBuilder code

### DIFF
--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1283,6 +1283,8 @@ class CodeGen(schemaFile: String, basePackage: String) {
 
     def generateNewNodeSource(nodeType: NodeType, keys: List[Property]) = {
       var fieldDescriptions = List[(String, String, Option[String])]() // fieldName, type, default
+      // Add ID as a modifiable field
+      fieldDescriptions = ("id", "Long", Some("null")) :: fieldDescriptions
       for (key <- keys) {
         val optionalDefault =
           if (getHigherType(key) == HigherValueType.Option) Some("None")

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1283,8 +1283,6 @@ class CodeGen(schemaFile: String, basePackage: String) {
 
     def generateNewNodeSource(nodeType: NodeType, keys: List[Property]) = {
       var fieldDescriptions = List[(String, String, Option[String])]() // fieldName, type, default
-      // Add ID as a modifiable field
-      fieldDescriptions = ("id", "Long", Some("null")) :: fieldDescriptions
       for (key <- keys) {
         val optionalDefault =
           if (getHigherType(key) == HigherValueType.Option) Some("None")

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1369,7 +1369,7 @@ class CodeGen(schemaFile: String, basePackage: String) {
       s"""
          |class New${nodeType.className}Builder {
          |   var result : New${nodeType.className} = New${nodeType.className}()
-         |   var id : Long = Some(-1L)
+         |   var id : Long = -1L
          |
          |   $builderSetters
          |

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1369,6 +1369,7 @@ class CodeGen(schemaFile: String, basePackage: String) {
       s"""
          |class New${nodeType.className}Builder {
          |   var result : New${nodeType.className} = New${nodeType.className}()
+         |   var id : Long = Some(-1L)
          |
          |   $builderSetters
          |


### PR DESCRIPTION
Added `id` as a field to the node builder class so that one can specify the ID of a node before giving it to `overflowdb.Graph#addNode`.