### PR TITLE
Enhanced NewNodeBuilders for better ID object comparisons

### DIFF
--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1282,6 +1282,7 @@ class CodeGen(schemaFile: String, basePackage: String) {
          |
          |trait NewNodeBuilder {
          |  def id : Long
+         |  def id(x: Long) : NewNodeBuilder
          |  def build : NewNode
          |}
          |""".stripMargin

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1380,7 +1380,21 @@ class CodeGen(schemaFile: String, basePackage: String) {
          |   $builderSetters
          |
          |   def build : New${nodeType.className} = result
-         | }
+         |
+         |   def canEqual(other: Any): Boolean = other.isInstanceOf[New${nodeType.className}Builder]
+         |
+         |   override def equals(other: Any): Boolean = other match {
+         |      case that: New${nodeType.className}Builder => (that canEqual this) && _id == that._id
+         |      case _ => false
+         |   }
+         |
+         |   override def hashCode(): Int = {
+         |      val state = Seq(_id)
+         |      state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+         |   }
+         |
+         |   override def toString = s"New${nodeType.className}Builder($${_id})"
+         |}
          |
          |object New${nodeType.className}{
          |  def apply(${defaultsNoVal}): New${nodeType.className} = new New${nodeType.className}($paramId)


### PR DESCRIPTION
Enhanced `NewNodeBuilder`s in the following ways to aid integration with Plume:

- ID setter was added to `NewNodeBuilder` trait.
- Override toString to show class and ID
- Override equals based on ID and type
- Override hashCode based on ID

Note: These overrides are from Intellij's generated code functionality.