### PR TITLE
Tweaks for builders (when accessed from Scala)

### DIFF
--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1383,6 +1383,10 @@ class CodeGen(schemaFile: String, basePackage: String) {
         .mkString("\n")
 
       s"""
+         |object New${nodeType.className}Builder {
+         |  def apply() : New${nodeType.className}Builder = new New${nodeType.className}Builder()
+         |}
+         |
          |class New${nodeType.className}Builder extends NewNodeBuilder {
          |   var result : New${nodeType.className} = New${nodeType.className}()
          |   private var _id : Long = -1L


### PR DESCRIPTION
* Introduce implicit conversions from New$TypeBuilder to New$Type
* Introduce companion objects for New$TypeBuilder with type instantiation via `apply()` method
