### PR TITLE
Fix camel case for builder setters

### DIFF
--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1379,7 +1379,7 @@ class CodeGen(schemaFile: String, basePackage: String) {
       }
 
       val builderSetters = fieldDescriptions
-        .map {case (name, typ, _) => s"def ${camelCase(name)}(x : $typ) : New${nodeType.className}Builder = { result = result.copy($name = x); this }" }
+        .map {case (name, typ, _) => s"def ${name}(x : $typ) : New${nodeType.className}Builder = { result = result.copy($name = x); this }" }
         .mkString("\n")
 
       s"""


### PR DESCRIPTION
Turned out the setters on builders were not camel case as they should have been because I called `camelCase` on a string that was already in camel case, in which case we obtain the string in all lower case.