### PR TITLE
More tweaks for builder/prohibit use of NewNode constructors

### DIFF
--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1413,6 +1413,7 @@ class CodeGen(schemaFile: String, basePackage: String) {
          |}
          |
          |object New${nodeType.className}{
+         |  def apply() : New${nodeType.className}Builder = New${nodeType.className}Builder()
          |  private def apply(${defaultsNoVal}): New${nodeType.className} = new New${nodeType.className}($paramId)
          |}
          |

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1388,7 +1388,7 @@ class CodeGen(schemaFile: String, basePackage: String) {
          |}
          |
          |class New${nodeType.className}Builder extends NewNodeBuilder {
-         |   var result : New${nodeType.className} = New${nodeType.className}()
+         |   var result : New${nodeType.className} = new New${nodeType.className}()
          |   private var _id : Long = -1L
          |   def id: Long = _id
          |   def id(x: Long): New${nodeType.className}Builder = { _id = x; this }
@@ -1413,11 +1413,10 @@ class CodeGen(schemaFile: String, basePackage: String) {
          |}
          |
          |object New${nodeType.className}{
-         |  def apply(${defaultsNoVal}): New${nodeType.className} = new New${nodeType.className}($paramId)
-         |
+         |  private def apply(${defaultsNoVal}): New${nodeType.className} = new New${nodeType.className}($paramId)
          |}
          |
-         |case class New${nodeType.className}($defaultsVal) extends NewNode with ${nodeType.className}Base {
+         |case class New${nodeType.className} private[nodes] ($defaultsVal) extends NewNode with ${nodeType.className}Base {
          |  override def label:String = "${nodeType.name}"
          |
          |  $valueMapImpl


### PR DESCRIPTION
* Disallow `new New$Type()`
* `New$Type()` returns a `New$TypeBuilder`

Do not merge yet. We need to ensure that all instances of

`nodes.New$Type(foo = bar, ...)`

are replaced with

`nodes.New$Type().foo(bar)...`
