### PR TITLE
Constants File ALL Field

### DIFF
--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -38,15 +38,29 @@ class CodeGen(schemaFile: String, basePackage: String) {
            | ${mkSrc(constant)}
            |""".stripMargin
       }.mkString("\n")
-
+      val setType = if (src.contains("PropertyKey")) "PropertyKey" else "String"
+      val constantsSetBody = constants.map { constant =>
+        s"     add(${constant.name});"
+      }.mkString("\n").stripSuffix("\n")
+      val constantsSet =
+        s"""
+           | public static Set<$setType> ALL = new HashSet<>() {{
+           |$constantsSetBody
+           | }};
+           |""".stripMargin
       baseDir.createChild(s"$className.java").write(
         s"""package io.shiftleft.codepropertygraph.generated;
            |
            |import overflowdb.*;
            |
+           |import java.util.Collection;
+           |import java.util.HashSet;
+           |import java.util.Set;
+           |
            |public class $className {
            |
            |$src
+           |$constantsSet
            |}""".stripMargin
       )
     }


### PR DESCRIPTION
Modified `CodeGen::writeConstantsFile` to add a field called `ALL` to all constants files. This is a `HashSet` containing all the fields in that constant file. e.g. `EdgeKeys.java` would show
```java
public static Set<PropertyKey> ALL = new HashSet<>() {{
     add(ALIAS);
     add(LOCAL_NAME);
     add(INDEX);
     add(VARIABLE);
}};
```

My desire for this change is that, since Plume supports other database backends that require pre-defined schemas, I would like to generate my own GSQL or Gremlin schemas for those databases based on the Semantic Code Property Graph that Plume is using in the given version.