### PR TITLE
HashSet type is now specified on RHS

### DIFF
--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -44,7 +44,7 @@ class CodeGen(schemaFile: String, basePackage: String) {
       }.mkString("\n").stripSuffix("\n")
       val constantsSet =
         s"""
-           | public static Set<$setType> ALL = new HashSet<>() {{
+           | public static Set<$setType> ALL = new HashSet<$setType>() {{
            |$constantsSetBody
            | }};
            |""".stripMargin


### PR DESCRIPTION
This attempts to fix a bug where the RHS of `Set`'s type wasn't being correctly inferred in JDK8