### PR TITLE
proto ids only need to be unique *within* one category

### DIFF
--- a/src/main/scala/overflowdb/schema/SchemaBuilder.scala
+++ b/src/main/scala/overflowdb/schema/SchemaBuilder.scala
@@ -58,20 +58,20 @@ class SchemaBuilder(basePackage: String) {
 
   /** proto ids must be unique (if used) */
   def verifyProtoIdsUnique: Unit = {
-    val elementsWithProtoId: Seq[HasOptionalProtoId] =
-      (propertyKeys ++ nodeTypes ++ edgeTypes ++ constantsByCategory.values.flatten)
-        .toSeq
-        .filter(_.protoId.isDefined)
-
-    val duplicates = elementsWithProtoId.groupBy(_.protoId.get).filter(_._2.size > 1)
-    if (duplicates.nonEmpty) {
-      throw new AssertionError(
-        s"proto ids must be unique across all schema elements, however we found " +
-          s"the following duplicates: protoId -> Seq[SchemaElement]: \n" +
-          duplicates.mkString("\n")
-      )
+    def ensureNoDuplicateProtoIds(elements: Seq[HasOptionalProtoId]): Unit = {
+      val elementsWithProtoId = elements.filter(_.protoId.isDefined)
+      val duplicates = elementsWithProtoId.groupBy(_.protoId.get).filter(_._2.size > 1)
+      if (duplicates.nonEmpty) {
+        throw new AssertionError(
+          s"proto ids must be unique across all schema elements, however we found " +
+            s"the following duplicates: protoId -> Seq[SchemaElement]: \n" +
+            duplicates.mkString("\n")
+        )
+      }
     }
 
+    val schemaElementCategories = Seq(propertyKeys, nodeTypes, edgeTypes) ++ constantsByCategory.values
+    schemaElementCategories.map(_.toSeq).foreach(ensureNoDuplicateProtoIds)
   }
 
   private def addAndReturn[A](buffer: mutable.Buffer[A], a: A): A = {

--- a/src/main/scala/overflowdb/schema/SchemaBuilder.scala
+++ b/src/main/scala/overflowdb/schema/SchemaBuilder.scala
@@ -65,7 +65,7 @@ class SchemaBuilder(basePackage: String) {
         throw new AssertionError(
           s"proto ids must be unique across all schema elements, however we found " +
             s"the following duplicates:\n" +
-            duplicates.view.mapValues(_.mkString(", ")).mkString("\n")
+            duplicates.map { case (protoId , elements) => s"$protoId -> ${elements.mkString(",")}"}.mkString
         )
       }
     }

--- a/src/main/scala/overflowdb/schema/SchemaBuilder.scala
+++ b/src/main/scala/overflowdb/schema/SchemaBuilder.scala
@@ -64,8 +64,8 @@ class SchemaBuilder(basePackage: String) {
       if (duplicates.nonEmpty) {
         throw new AssertionError(
           s"proto ids must be unique across all schema elements, however we found " +
-            s"the following duplicates: protoId -> Seq[SchemaElement]: \n" +
-            duplicates.mkString("\n")
+            s"the following duplicates:\n" +
+            duplicates.view.mapValues(_.mkString(", ")).mkString("\n")
         )
       }
     }

--- a/src/test/scala/overflowdb/schema/SchemaBuilderTest.scala
+++ b/src/test/scala/overflowdb/schema/SchemaBuilderTest.scala
@@ -7,11 +7,18 @@ class SchemaBuilderTest extends AnyWordSpec {
 
   "proto ids must be unique within one category" in {
     val schemaModifications: Seq[(String, SchemaBuilder => Any)] = Seq(
-      ("property", _.addProperty(name = "prop", valueType = ValueTypes.STRING, cardinality = Cardinality.One).protoId(10)),
       ("node", _.addNodeType("testNode").protoId(10)),
       ("edge", _.addEdgeType("testEdge").protoId(10)),
       ("category1", _.addConstants("category1", Constant("constant1", "value1", ValueTypes.STRING).protoId(10))),
       ("category2", _.addConstants("category2", Constant("constant2", "value2", ValueTypes.STRING).protoId(10))),
+      ("node property", { schemaBuilder =>
+        val property = schemaBuilder.addProperty(name = "prop", valueType = ValueTypes.STRING, cardinality = Cardinality.One).protoId(10)
+        schemaBuilder.addNodeType("testNode").addProperty(property)
+      }),
+      ("edge property", { schemaBuilder =>
+        val property = schemaBuilder.addProperty(name = "prop", valueType = ValueTypes.STRING, cardinality = Cardinality.One).protoId(10)
+        schemaBuilder.addEdgeType("testEdge").addProperty(property)
+      }),
     )
 
 


### PR DESCRIPTION
fixes a previous wrong assumption in #52