### PR TITLE
add SchemaInfo, an optional setting that let's us remember where the element was defined

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.1
+sbt.version=1.5.2

--- a/src/main/scala/overflowdb/schema/SchemaBuilder.scala
+++ b/src/main/scala/overflowdb/schema/SchemaBuilder.scala
@@ -19,19 +19,27 @@ class SchemaBuilder(basePackage: String) {
    * it's not even part of the regular base types, but instead defined in the RootTypes.scala
    * */
   lazy val anyNode: NodeBaseType =
-    new NodeBaseType(DefaultNodeTypes.AbstractNodeName, Some("generic node base trait - use if you want to be explicitly unspecific"))
+    new NodeBaseType(
+      DefaultNodeTypes.AbstractNodeName,
+      Some("generic node base trait - use if you want to be explicitly unspecific"),
+      SchemaInfo.forClass(getClass)
+    )
 
-  def addProperty(name: String, valueType: ValueTypes, cardinality: Cardinality, comment: String = ""): Property =
-    addAndReturn(properties, new Property(name, stringToOption(comment), valueType, cardinality))
+  def addProperty(name: String, valueType: ValueTypes, cardinality: Cardinality, comment: String = "")(
+    implicit schemaInfo: SchemaInfo = SchemaInfo.Unknown): Property =
+    addAndReturn(properties, new Property(name, stringToOption(comment), valueType, cardinality, schemaInfo))
 
-  def addNodeBaseType(name: String, comment: String = ""): NodeBaseType =
-    addAndReturn(nodeBaseTypes, new NodeBaseType(name, stringToOption(comment)))
+  def addNodeBaseType(name: String, comment: String = "")(
+    implicit schemaInfo: SchemaInfo = SchemaInfo.Unknown): NodeBaseType =
+    addAndReturn(nodeBaseTypes, new NodeBaseType(name, stringToOption(comment), schemaInfo))
 
-  def addEdgeType(name: String, comment: String = ""): EdgeType =
-    addAndReturn(edgeTypes, new EdgeType(name, stringToOption(comment)))
+  def addEdgeType(name: String, comment: String = "")(
+    implicit schemaInfo: SchemaInfo = SchemaInfo.Unknown): EdgeType =
+    addAndReturn(edgeTypes, new EdgeType(name, stringToOption(comment), schemaInfo))
 
-  def addNodeType(name: String, comment: String = ""): NodeType =
-    addAndReturn(nodeTypes, new NodeType(name, stringToOption(comment)))
+  def addNodeType(name: String, comment: String = "")(
+    implicit schemaInfo: SchemaInfo = SchemaInfo.Unknown): NodeType =
+    addAndReturn(nodeTypes, new NodeType(name, stringToOption(comment), schemaInfo))
 
   def addConstants(category: String, constants: Constant*): Seq[Constant] = {
     val previousEntries = constantsByCategory.getOrElse(category, Seq.empty)

--- a/src/main/scala/overflowdb/schema/testschema1/TestSchema1.scala
+++ b/src/main/scala/overflowdb/schema/testschema1/TestSchema1.scala
@@ -2,12 +2,15 @@ package overflowdb.schema.testschema1
 
 import java.io.File
 import overflowdb.codegen.CodeGen
-import overflowdb.schema.{Cardinality, Constant, SchemaBuilder}
+import overflowdb.schema.SchemaInfo.forClass
+import overflowdb.schema.{Cardinality, Constant, SchemaBuilder, SchemaInfo}
 import overflowdb.storage.ValueTypes
 
 // TODO create integration test from this
 object TestSchema1 extends App {
   val builder = new SchemaBuilder("io.shiftleft.codepropertygraph.generated")
+
+  implicit val schemaInfo = SchemaInfo.forClass(getClass)
 
   // properties
   val name = builder


### PR DESCRIPTION
usage:
```
implicit val schemaInfo = SchemaInfo.forClass(getClass)
builder.addNode(...)
```

if that implicit is not defined, a default "unknown" value is used - to not disturb users who don't care about this