### PR TITLE
allow to define edges on base nodes, and add type-specific neighbor accessors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 name := "overflowdb-codegen"
 organization := "io.shiftleft"
 
-scalaVersion := "2.13.5"
-crossScalaVersions := Seq("2.12.13", "2.13.5")
+scalaVersion := "2.13.6"
+crossScalaVersions := Seq("2.12.13", "2.13.6")
 
 enablePlugins(GitVersioning)
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ crossScalaVersions := Seq("2.12.13", "2.13.6")
 enablePlugins(GitVersioning)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" % "overflowdb-core" % "1.31",
+  "io.shiftleft" % "overflowdb-core" % "1.38",
   "com.github.pathikrit" %% "better-files" % "3.8.0",
   "org.scalatest" %% "scalatest" % "3.2.7" % Test,
 )

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1070,12 +1070,13 @@ class CodeGen(schema: Schema) {
            |""".stripMargin
       }
 
-      val neighborAccessors = neighborInfos.map { case (NeighborInfo(edge, neighborNodeInfo, offsetPos), direction) =>
-        val accessorNameForEdge = neighborAccessorNameForEdge(edge, direction)
+      val neighborAccessors = neighborInfos.map { case (neighborInfo, direction) =>
+        val accessorNameForEdge = neighborAccessorNameForEdge(neighborInfo.edge, direction)
+        val accessorReturnType = s"java.util.Iterator[${neighborInfo.deriveNeighborNodeType}]"
         val genericEdgeBasedAccessor =
-          s"override def $accessorNameForEdge: java.util.Iterator[StoredNode] = createAdjacentNodeIteratorByOffSet($offsetPos).asInstanceOf[java.util.Iterator[StoredNode]]"
+          s"override def $accessorNameForEdge: $accessorReturnType = createAdjacentNodeIteratorByOffSet(${neighborInfo.offsetPosition}).asInstanceOf[$accessorReturnType]"
 
-        val specificNodeBasedAccessors = neighborNodeInfo.map {
+        val specificNodeBasedAccessors = neighborInfo.nodeInfos.map {
           case NeighborNodeInfo(accessorNameForNode, className, cardinality) =>
             cardinality match {
               case Cardinality.List =>

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -730,16 +730,16 @@ class CodeGen(schema: Schema) {
         var _currOffsetPos = -1
         def nextOffsetPos = { _currOffsetPos += 1; _currOffsetPos }
 
-        def createNeighborNodeInfo(nodeName: String, neighborClassName: String, edgeAndDirection: String, cardinality: Cardinality) = {
-          val accessorName = s"_${camelCase(nodeName)}Via${edgeAndDirection.capitalize}"
-          NeighborNodeInfo(Helpers.escapeIfKeyword(accessorName), neighborClassName, cardinality)
+        def createNeighborNodeInfo(node: AbstractNodeType, edgeAndDirection: String, cardinality: Cardinality) = {
+          val accessorName = s"_${camelCase(node.name)}Via${edgeAndDirection.capitalize}"
+          NeighborNodeInfo(Helpers.escapeIfKeyword(accessorName), node, cardinality)
         }
 
         val neighborOutInfos =
           nodeType.outEdges.groupBy(_.viaEdge).map { case (edge, outEdges) =>
             val viaEdgeAndDirection = edge.className + "Out"
             val neighborNodeInfos = outEdges.map { case AdjacentNode(_, inNode, cardinality) =>
-              createNeighborNodeInfo(inNode.name, inNode.className, viaEdgeAndDirection, cardinality)
+              createNeighborNodeInfo(inNode, viaEdgeAndDirection, cardinality)
             }
             NeighborInfo(edge, neighborNodeInfos, nextOffsetPos)
           }.toSeq
@@ -748,7 +748,7 @@ class CodeGen(schema: Schema) {
           nodeType.inEdges.groupBy(_.viaEdge).map { case (edge, inEdges) =>
             val viaEdgeAndDirection = edge.className + "In"
             val neighborNodeInfos = inEdges.map { case AdjacentNode(_, outNode, cardinality) =>
-              createNeighborNodeInfo(outNode.name, outNode.className, viaEdgeAndDirection, cardinality)
+              createNeighborNodeInfo(outNode, viaEdgeAndDirection, cardinality)
             }
             NeighborInfo(edge, neighborNodeInfos, nextOffsetPos)
           }.toSeq

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -702,16 +702,13 @@ class CodeGen(schema: Schema) {
             val entireNodeHierarchy: Set[AbstractNodeType] = neighbor.subtypes(schema.allNodeTypes.toSet) ++ (neighbor.extendzRecursively :+ neighbor)
             entireNodeHierarchy.map { neighbor =>
               val accessorName = s"_${camelCase(neighbor.name)}Via${edge.className.capitalize}${camelCaseCaps(direction.toString)}"
-              val className = neighbor.className
-              adjacentNode.cardinality match {
-                case Cardinality.List =>
-                  s"def $accessorName: Iterator[$className] = _$edgeAccessorName.asScala.collect { case node: $className => node }"
-                case Cardinality.ZeroOrOne =>
-                  s"def $accessorName: Option[$className] = _$edgeAccessorName.asScala.collect { case node: $className => node }.nextOption()"
-                case Cardinality.One =>
-                  s"def $accessorName: $className = _$edgeAccessorName.asScala.collect { case node: $className => node }.next()"
-                case Cardinality.ISeq => ???
+              val cardinality = adjacentNode.cardinality
+              val appendix = cardinality match {
+                case Cardinality.One => ".next()"
+                case Cardinality.ZeroOrOne => s".nextOption()"
+                case _ => ""
               }
+              s"def $accessorName: ${fullScalaType(neighbor, cardinality)} = $edgeAccessorName.collectAll[${neighbor.className}]$appendix"
             }
           }.mkString("\n\n")
 
@@ -762,31 +759,31 @@ class CodeGen(schema: Schema) {
         var _currOffsetPos = -1
         def nextOffsetPos = { _currOffsetPos += 1; _currOffsetPos }
 
-        def createNeighborNodeInfo(node: AbstractNodeType, edgeAndDirection: String, cardinality: Cardinality) = {
+        def createNeighborNodeInfo(node: AbstractNodeType, edgeAndDirection: String, cardinality: Cardinality, isInherited: Boolean) = {
           val accessorName = s"_${camelCase(node.name)}Via${edgeAndDirection.capitalize}"
-          NeighborNodeInfo(Helpers.escapeIfKeyword(accessorName), node, cardinality)
+          NeighborNodeInfo(Helpers.escapeIfKeyword(accessorName), node, cardinality, isInherited)
         }
 
-        val neighborOutInfos =
-          nodeType.outEdges.groupBy(_.viaEdge).map { case (edge, outEdges) =>
-            val viaEdgeAndDirection = edge.className + "Out"
-            val neighborNodeInfos = outEdges.map { case AdjacentNode(_, inNode, cardinality) =>
-              createNeighborNodeInfo(inNode, viaEdgeAndDirection, cardinality)
-            }
-            NeighborInfo(edge, neighborNodeInfos, nextOffsetPos)
-          }.toSeq
+        def neighborContexts(adjacentNodes: AbstractNodeType => Seq[AdjacentNode]): Seq[NeighborContext] = {
+          adjacentNodes(nodeType).map(NeighborContext(_, false)) ++
+            nodeType.extendzRecursively.flatMap(adjacentNodes).map(NeighborContext(_, true))
+        }
 
-        val neighborInInfos =
-          nodeType.inEdges.groupBy(_.viaEdge).map { case (edge, inEdges) =>
-            val viaEdgeAndDirection = edge.className + "In"
-            val neighborNodeInfos = inEdges.map { case AdjacentNode(_, outNode, cardinality) =>
-              createNeighborNodeInfo(outNode, viaEdgeAndDirection, cardinality)
+        def createNeighborInfos(neighborContexts: Seq[NeighborContext], direction: Direction.Value): Seq[NeighborInfo] = {
+          neighborContexts.groupBy(_.adjacentNode.viaEdge).map { case (edgeType, neighborContexts) =>
+            val viaEdgeAndDirection = edgeType.className + camelCaseCaps(direction.toString)
+            val neighborNodeInfos = neighborContexts.map { case NeighborContext(adjacentNode, isInherited) =>
+              createNeighborNodeInfo(adjacentNode.neighbor, viaEdgeAndDirection, adjacentNode.cardinality, isInherited)
             }
-            NeighborInfo(edge, neighborNodeInfos, nextOffsetPos)
+            NeighborInfo(edgeType, neighborNodeInfos, nextOffsetPos)
           }.toSeq
+        }
 
+        val neighborOutInfos = createNeighborInfos(neighborContexts(_.outEdges), Direction.OUT)
+        val neighborInInfos = createNeighborInfos(neighborContexts(_.inEdges), Direction.IN)
         (neighborOutInfos, neighborInInfos)
       }
+
       val neighborInfos: Seq[(NeighborInfo, Direction.Value)] =
         neighborOutInfos.map((_, Direction.OUT)) ++ neighborInInfos.map((_, Direction.IN))
 
@@ -1049,8 +1046,8 @@ class CodeGen(schema: Schema) {
 
       val neighborAccessorDelegators = neighborInfos.map { case (neighborInfo, direction) =>
         val edgeAccessorName = neighborAccessorNameForEdge(neighborInfo.edge, direction)
-        val nodeDelegators = neighborInfo.nodeInfos.map {
-          case NeighborNodeInfo(accessorNameForNode, neighborNode, cardinality) =>
+        val nodeDelegators = neighborInfo.nodeInfos.collect {
+          case NeighborNodeInfo(accessorNameForNode, neighborNode, cardinality, isInherited) if !isInherited =>
             val returnType = fullScalaType(neighborNode, cardinality)
             s"def $accessorNameForNode: $returnType = get().$accessorNameForNode"
         }.mkString("\n")
@@ -1103,8 +1100,8 @@ class CodeGen(schema: Schema) {
         val neighborType = neighborInfo.deriveNeighborNodeType
         val offsetPosition = neighborInfo.offsetPosition
 
-        val nodeAccessors = neighborInfo.nodeInfos.map {
-          case NeighborNodeInfo(accessorNameForNode, neighborNode, cardinality) =>
+        val nodeAccessors = neighborInfo.nodeInfos.collect {
+          case NeighborNodeInfo(accessorNameForNode, neighborNode, cardinality, isInherited) if !isInherited =>
             val returnType = fullScalaType(neighborNode, cardinality)
             val appendix = cardinality match {
               case Cardinality.One => ".next()"

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1015,12 +1015,13 @@ class CodeGen(schema: Schema) {
            |}
            |""".stripMargin
 
-      val neighborDelegators = neighborInfos.map { case (NeighborInfo(edge, neighborNodeInfos, _), direction) =>
-        val accessorNameForEdge = neighborAccessorNameForEdge(edge, direction)
+      val neighborDelegators = neighborInfos.map { case (neighborInfo, direction) =>
+        val accessorNameForEdge = neighborAccessorNameForEdge(neighborInfo.edge, direction)
+        val accessorReturnType = s"java.util.Iterator[${neighborInfo.deriveNeighborNodeType}]"
         val genericEdgeBasedDelegators =
-          s"override def $accessorNameForEdge: java.util.Iterator[StoredNode] = get().$accessorNameForEdge"
+          s"override def $accessorNameForEdge: $accessorReturnType = get().$accessorNameForEdge"
 
-        val specificNodeBasedDelegators = neighborNodeInfos.map {
+        val specificNodeBasedDelegators = neighborInfo.nodeInfos.map {
           case NeighborNodeInfo(accessorNameForNode, className, cardinality) =>
             val returnType = cardinality match {
               case Cardinality.List => s"Iterator[$className]"

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -701,7 +701,7 @@ class CodeGen(schema: Schema) {
           val specificNodeAccessors = neighbors.map { adjacentNode =>
             // TODO do this for all supertypes of adjacentNode.neighbor
             val accessorName = s"_${camelCase(adjacentNode.neighbor.name)}Via${edge.className.capitalize}${camelCaseCaps(direction.toString)}"
-            s"def $accessorName: ${fullScalaType(className, adjacentNode.cardinality)} = ???"
+            s"def $accessorName: ${fullScalaType(adjacentNode.neighbor, adjacentNode.cardinality)} = ???"
           }.mkString("\n")
           s"""$genericEdgeAccessor
              |$specificNodeAccessors""".stripMargin
@@ -1042,8 +1042,9 @@ class CodeGen(schema: Schema) {
 
         val specificNodeBasedDelegators = neighborInfo.nodeInfos.map {
           case NeighborNodeInfo(accessorNameForNode, nodeType, cardinality) =>
-            s"def $accessorNameForNode: ${fullScalaType(nodeType.className, cardinality)} = get().$accessorNameForNode"
+            s"def $accessorNameForNode: ${fullScalaType(nodeType, cardinality)} = get().$accessorNameForNode"
         }.mkString("\n")
+        
         s"""$specificNodeBasedDelegators
            |$genericEdgeBasedDelegators""".stripMargin
       }.mkString("\n")

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -697,9 +697,9 @@ class CodeGen(schema: Schema) {
           val neighborNodesType = deriveCommonSuperType(neighbors.map(_.neighbor).toSet).map(_.className).getOrElse("StoredNode")
           val genericEdgeAccessor = s"def $edgeAccessorName: java.util.Iterator[$neighborNodesType]"
 
+          // TODO do this for all supertypes of adjacentNode.neighbor
           val specificNodeAccessors = neighbors.map { adjacentNode =>
             val neighbor = adjacentNode.neighbor
-            // TODO do this for all supertypes of adjacentNode.neighbor
             val accessorName = s"_${camelCase(neighbor.name)}Via${edge.className.capitalize}${camelCaseCaps(direction.toString)}"
             val className = neighbor.className
             adjacentNode.cardinality match {
@@ -712,7 +712,7 @@ class CodeGen(schema: Schema) {
               case Cardinality.ISeq => ???
             }
           }.mkString("\n\n")
-          
+
           s"""$genericEdgeAccessor
              |
              |$specificNodeAccessors""".stripMargin

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -202,7 +202,7 @@ class CodeGen(schema: Schema) {
   }
 
   protected def neighborAccessorNameForEdge(edge: EdgeType, direction: Direction.Value): String =
-    "_" + camelCase(edge.name + "_" + direction)
+    camelCase(edge.name + "_" + direction)
 
   protected def writeNodeFiles(outputDir: File): Seq[File] = {
     val rootTypeImpl = {
@@ -210,7 +210,7 @@ class CodeGen(schema: Schema) {
         direction <- Direction.all
         edgeType <- schema.edgeTypes
         accessor = neighborAccessorNameForEdge(edgeType, direction)
-      } yield s"def $accessor: java.util.Iterator[StoredNode] = { java.util.Collections.emptyIterator() }"
+      } yield s"def _$accessor: java.util.Iterator[StoredNode] = { java.util.Collections.emptyIterator() }"
 
       val keyBasedTraits =
         schema.nodeProperties.map { property =>
@@ -695,7 +695,7 @@ class CodeGen(schema: Schema) {
         neighbors.groupBy(_.viaEdge).map { case (edge, neighbors) =>
           val edgeAccessorName = neighborAccessorNameForEdge(edge, direction)
           val neighborNodesType = deriveCommonSuperType(neighbors.map(_.neighbor).toSet).map(_.className).getOrElse("StoredNode")
-          val genericEdgeAccessor = s"def $edgeAccessorName: java.util.Iterator[$neighborNodesType]"
+          val genericEdgeAccessor = s"def _$edgeAccessorName: java.util.Iterator[$neighborNodesType]"
 
           val specificNodeAccessors = neighbors.flatMap { adjacentNode =>
             val neighbor = adjacentNode.neighbor
@@ -1050,7 +1050,7 @@ class CodeGen(schema: Schema) {
       val edgeDelegators = neighborInfos.map { case (neighborInfo, direction) =>
         val accessorName = neighborAccessorNameForEdge(neighborInfo.edge, direction)
         val returnType = s"java.util.Iterator[${neighborInfo.deriveNeighborNodeType}]"
-        s"override def $accessorName: $returnType = get().$accessorName"
+        s"override def _$accessorName: $returnType = get().$accessorName"
       }.mkString("\n")
 
       val nodeRefImpl = {
@@ -1092,7 +1092,7 @@ class CodeGen(schema: Schema) {
       val edgeAccessors = neighborInfos.map { case (neighborInfo, direction) =>
         val accessorName = neighborAccessorNameForEdge(neighborInfo.edge, direction)
         val returnType = s"java.util.Iterator[${neighborInfo.deriveNeighborNodeType}]"
-        s"override def $accessorName: $returnType = createAdjacentNodeIteratorByOffSet(${neighborInfo.offsetPosition}).asInstanceOf[$returnType]"
+        s"override def _$accessorName: $returnType = createAdjacentNodeIteratorByOffSet(${neighborInfo.offsetPosition}).asInstanceOf[$returnType]"
       }.mkString("\n")
 
       val updateSpecificPropertyImpl: String = {

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -705,11 +705,11 @@ class CodeGen(schema: Schema) {
               val className = neighbor.className
               adjacentNode.cardinality match {
                 case Cardinality.List =>
-                  s"def $accessorName: Iterator[$className] = $edgeAccessorName.asScala.collect { case node: $className => node }"
+                  s"def $accessorName: Iterator[$className] = _$edgeAccessorName.asScala.collect { case node: $className => node }"
                 case Cardinality.ZeroOrOne =>
-                  s"def $accessorName: Option[$className] = $edgeAccessorName.asScala.collect { case node: $className => node }.nextOption()"
+                  s"def $accessorName: Option[$className] = _$edgeAccessorName.asScala.collect { case node: $className => node }.nextOption()"
                 case Cardinality.One =>
-                  s"def $accessorName: $className = $edgeAccessorName.asScala.collect { case node: $className => node }.next()"
+                  s"def $accessorName: $className = _$edgeAccessorName.asScala.collect { case node: $className => node }.next()"
                 case Cardinality.ISeq => ???
               }
             }

--- a/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -199,6 +199,6 @@ object Helpers {
   }
 
   def allTypes(node: AbstractNodeType): Seq[AbstractNodeType] =
-    node +: node.extendz.flatMap(allTypes)
+    node +: node.extendzRecursively
 
 }

--- a/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -201,4 +201,12 @@ object Helpers {
   def allTypes(node: AbstractNodeType): Seq[AbstractNodeType] =
     node +: node.extendzRecursively
 
+  def fullScalaType(neighborNodeClass: String, cardinality: Cardinality): String =
+    cardinality match {
+      case Cardinality.List => s"Iterator[$neighborNodeClass]"
+      case Cardinality.ZeroOrOne => s"Option[$neighborNodeClass]"
+      case Cardinality.One => s"$neighborNodeClass"
+      case Cardinality.ISeq => ???
+    }
+
 }

--- a/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -176,9 +176,6 @@ object Helpers {
     if (scalaReservedKeywords.contains(value)) s"`$value`"
     else value
 
-  /** try to find common supertype. this is nontrivial and we're probably missing a few cases.
-   * trying to at least keep it deterministic...
-   */
   def deriveCommonSuperType(nodeTypes: Set[AbstractNodeType]): Option[AbstractNodeType] = {
     if (nodeTypes.size == 1) {
       Some(nodeTypes.head)
@@ -187,8 +184,6 @@ object Helpers {
        * Trying to at least keep it deterministic...
        * Idea: take one nodeType and check if it's type or any of it's supertypes are declared in *all* other nodeTypes
        * */
-      def allTypes(node: AbstractNodeType): Seq[AbstractNodeType] =
-        node +: node.extendz
 
       val sorted = nodeTypes.toSeq.sortBy(_.className)
 
@@ -202,5 +197,8 @@ object Helpers {
       None
     }
   }
+
+  def allTypes(node: AbstractNodeType): Seq[AbstractNodeType] =
+    node +: node.extendz.flatMap(allTypes)
 
 }

--- a/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -201,12 +201,14 @@ object Helpers {
   def allTypes(node: AbstractNodeType): Seq[AbstractNodeType] =
     node +: node.extendzRecursively
 
-  def fullScalaType(neighborNodeClass: String, cardinality: Cardinality): String =
+  def fullScalaType(neighborNode: AbstractNodeType, cardinality: Cardinality): String = {
+    val neighborNodeClass = neighborNode.className
     cardinality match {
       case Cardinality.List => s"Iterator[$neighborNodeClass]"
       case Cardinality.ZeroOrOne => s"Option[$neighborNodeClass]"
       case Cardinality.One => s"$neighborNodeClass"
       case Cardinality.ISeq => ???
     }
+  }
 
 }

--- a/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -183,8 +183,18 @@ object Helpers {
     if (nodeTypes.size == 1) {
       Some(nodeTypes.head)
     } else if (nodeTypes.size > 1) {
-      /** try to find common supertype. this is nontrivial and we're probably missing a few cases.
-       * trying to at least keep it deterministic... */
+      /** Trying to find common supertype. This is nontrivial and we're probably missing a few cases.
+       * Trying to at least keep it deterministic...
+       * Idea: take one nodeType and check if it's type or any of it's supertypes are declared in *all* other nodeTypes
+       * */
+      val sorted = nodeTypes.toSeq.sortBy(_.className)
+      val (first, other) = (sorted.head, sorted.tail)
+      val candidates: Seq[AbstractNodeType] = first +: first.extendz
+      candidates.find { candidate =>
+        false
+      }
+
+
       //      def deriveCommonSuperType(nodeTypes: Set[AbstractNodeType]): Option[AbstractNodeType] =
       //      Helpers.deriveCommonSuperType(nodeInfosSet).map(_.className).getOrElse(defaultNodeType)
       // "TODO"

--- a/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -204,7 +204,7 @@ object Helpers {
   def fullScalaType(neighborNode: AbstractNodeType, cardinality: Cardinality): String = {
     val neighborNodeClass = neighborNode.className
     cardinality match {
-      case Cardinality.List => s"Iterator[$neighborNodeClass]"
+      case Cardinality.List => s"Traversal[$neighborNodeClass]"
       case Cardinality.ZeroOrOne => s"Option[$neighborNodeClass]"
       case Cardinality.One => s"$neighborNodeClass"
       case Cardinality.ISeq => ???

--- a/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -176,4 +176,22 @@ object Helpers {
     if (scalaReservedKeywords.contains(value)) s"`$value`"
     else value
 
+  /** try to find common supertype. this is nontrivial and we're probably missing a few cases.
+   * trying to at least keep it deterministic...
+   */
+  def deriveCommonSuperType(nodeTypes: Set[AbstractNodeType]): Option[AbstractNodeType] = {
+    if (nodeTypes.size == 1) {
+      Some(nodeTypes.head)
+    } else if (nodeTypes.size > 1) {
+      /** try to find common supertype. this is nontrivial and we're probably missing a few cases.
+       * trying to at least keep it deterministic... */
+      //      def deriveCommonSuperType(nodeTypes: Set[AbstractNodeType]): Option[AbstractNodeType] =
+      //      Helpers.deriveCommonSuperType(nodeInfosSet).map(_.className).getOrElse(defaultNodeType)
+      // "TODO"
+      ???
+    } else {
+      None
+    }
+  }
+
 }

--- a/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -187,18 +187,17 @@ object Helpers {
        * Trying to at least keep it deterministic...
        * Idea: take one nodeType and check if it's type or any of it's supertypes are declared in *all* other nodeTypes
        * */
+      def allTypes(node: AbstractNodeType): Seq[AbstractNodeType] =
+        node +: node.extendz
+
       val sorted = nodeTypes.toSeq.sortBy(_.className)
-      val (first, other) = (sorted.head, sorted.tail)
-      val candidates: Seq[AbstractNodeType] = first +: first.extendz
-      candidates.find { candidate =>
-        false
+
+      val (first, otherNodes) = (sorted.head, sorted.tail)
+      allTypes(first).find { candidate =>
+        otherNodes.forall { otherNode =>
+          allTypes(otherNode).contains(candidate)
+        }
       }
-
-
-      //      def deriveCommonSuperType(nodeTypes: Set[AbstractNodeType]): Option[AbstractNodeType] =
-      //      Helpers.deriveCommonSuperType(nodeInfosSet).map(_.className).getOrElse(defaultNodeType)
-      // "TODO"
-      ???
     } else {
       None
     }

--- a/src/main/scala/overflowdb/schema/Schema.scala
+++ b/src/main/scala/overflowdb/schema/Schema.scala
@@ -150,9 +150,10 @@ object Constant {
 
 case class NeighborNodeInfo(accessorName: String, className: String, cardinality: Cardinality)
 case class NeighborInfo(edge: EdgeType, nodeInfos: Seq[NeighborNodeInfo], offsetPosition: Int) {
-  lazy val deriveNeighborNodeType: String = nodeInfos match {
-    case Seq(singleEntry) => singleEntry.className
-    case _ => "StoredNode"
+  lazy val deriveNeighborNodeType: String = {
+    val nodeInfosSet = nodeInfos.map(_.className).toSet
+    if (nodeInfosSet.size == 1) nodeInfosSet.head
+    else "StoredNode"
   }
 }
 

--- a/src/main/scala/overflowdb/schema/Schema.scala
+++ b/src/main/scala/overflowdb/schema/Schema.scala
@@ -35,6 +35,9 @@ abstract class AbstractNodeType(val name: String, val comment: Option[String], v
   protected val _outEdges: mutable.Set[AdjacentNode] = mutable.Set.empty
   protected val _inEdges: mutable.Set[AdjacentNode] = mutable.Set.empty
 
+  /** all node types that extend this node */
+  def subtypes(allNodes: Set[AbstractNodeType]): Set[AbstractNodeType]
+
   override def properties: Seq[Property] = {
     /* only to provide feedback for potential schema optimisation: no need to redefine properties if they are already
      * defined in one of the parents */
@@ -94,6 +97,9 @@ class NodeType(name: String, comment: Option[String], schemaInfo: SchemaInfo)
 
   lazy val classNameDb = s"${className}Db"
 
+  /** all node types that extend this node */
+  override def subtypes(allNodes: Set[AbstractNodeType]) = Set.empty
+
   def containedNodes: Seq[ContainedNode] =
     _containedNodes.toSeq.sortBy(_.localName.toLowerCase)
 
@@ -107,6 +113,13 @@ class NodeType(name: String, comment: Option[String], schemaInfo: SchemaInfo)
 
 class NodeBaseType(name: String, comment: Option[String], schemaInfo: SchemaInfo)
   extends AbstractNodeType(name, comment, schemaInfo) {
+
+  /** all node types that extend this node */
+  override def subtypes(allNodes: Set[AbstractNodeType]) =
+    allNodes.filter { candidate =>
+      candidate.extendzRecursively.contains(this)
+    }
+
   override def toString = s"NodeBaseType($name)"
 }
 

--- a/src/main/scala/overflowdb/schema/Schema.scala
+++ b/src/main/scala/overflowdb/schema/Schema.scala
@@ -6,7 +6,7 @@ import overflowdb.storage.ValueTypes
 import scala.collection.mutable
 
 /**
-* @param basePackage: specific for your domain, e.g. `com.example.mydomain`
+ * @param basePackage: specific for your domain, e.g. `com.example.mydomain`
  */
 class Schema(val basePackage: String,
              val properties: Seq[Property],
@@ -89,10 +89,10 @@ abstract class AbstractNodeType(val name: String, val comment: Option[String], v
   }
 
   def outEdges: Seq[AdjacentNode] =
-    (_outEdges ++ _extendz.flatMap(_.outEdges)).toSeq
+    _outEdges.toSeq
 
   def inEdges: Seq[AdjacentNode] =
-    (_inEdges ++ _extendz.flatMap(_.inEdges)).toSeq
+    _inEdges.toSeq
 }
 
 class NodeType(name: String, comment: Option[String], schemaInfo: SchemaInfo)
@@ -171,7 +171,7 @@ object Constant {
     new Constant(name, value, valueType, stringToOption(comment), schemaInfo)
 }
 
-case class NeighborNodeInfo(accessorName: String, node: AbstractNodeType, cardinality: Cardinality)
+case class NeighborNodeInfo(accessorName: String, node: AbstractNodeType, cardinality: Cardinality, isInherited: Boolean)
 
 case class NeighborInfo(edge: EdgeType, nodeInfos: Seq[NeighborNodeInfo], offsetPosition: Int) {
   lazy val deriveNeighborNodeType: String = {
@@ -180,6 +180,8 @@ case class NeighborInfo(edge: EdgeType, nodeInfos: Seq[NeighborNodeInfo], offset
       .getOrElse("StoredNode")
   }
 }
+
+case class NeighborContext(adjacentNode: AdjacentNode, isInherited: Boolean)
 
 object HigherValueType extends Enumeration {
   type HigherValueType = Value

--- a/src/main/scala/overflowdb/schema/Schema.scala
+++ b/src/main/scala/overflowdb/schema/Schema.scala
@@ -55,6 +55,11 @@ abstract class AbstractNodeType(val name: String, val comment: Option[String], v
   def extendz: Seq[NodeBaseType] =
     _extendz.toSeq
 
+  def extendzRecursively: Seq[NodeBaseType] = {
+    val extendsLevel1 = extendz
+    extendsLevel1 ++ extendsLevel1.flatMap(_.extendzRecursively)
+  }
+
   /**
    * note: allowing to define one outEdge for ONE inNode only - if you are looking for Union Types, please use NodeBaseTypes
    */

--- a/src/main/scala/overflowdb/schema/Schema.scala
+++ b/src/main/scala/overflowdb/schema/Schema.scala
@@ -16,6 +16,10 @@ class Schema(val basePackage: String,
              val constantsByCategory: Map[String, Seq[Constant]],
              val protoOptions: Option[ProtoOptions]) {
 
+  /** nodeTypes and nodeBaseTypes combined */
+  lazy val allNodeTypes: Seq[AbstractNodeType] =
+    nodeTypes ++ nodeBaseTypes
+
   /** properties that are used in node types */
   def nodeProperties: Seq[Property] =
     properties.filter(property =>

--- a/src/main/scala/overflowdb/schema/Schema.scala
+++ b/src/main/scala/overflowdb/schema/Schema.scala
@@ -149,7 +149,12 @@ object Constant {
 }
 
 case class NeighborNodeInfo(accessorName: String, className: String, cardinality: Cardinality)
-case class NeighborInfo(edge: EdgeType, nodeInfos: Seq[NeighborNodeInfo], offsetPosition: Int)
+case class NeighborInfo(edge: EdgeType, nodeInfos: Seq[NeighborNodeInfo], offsetPosition: Int) {
+  lazy val deriveNeighborNodeType: String = nodeInfos match {
+    case Seq(singleEntry) => singleEntry.className
+    case _ => "StoredNode"
+  }
+}
 
 object HigherValueType extends Enumeration {
   type HigherValueType = Value

--- a/src/main/scala/overflowdb/schema/Schema.scala
+++ b/src/main/scala/overflowdb/schema/Schema.scala
@@ -2,6 +2,7 @@ package overflowdb.schema
 
 import overflowdb.codegen.Helpers._
 import overflowdb.storage.ValueTypes
+
 import scala.collection.mutable
 
 /**
@@ -149,11 +150,24 @@ object Constant {
 }
 
 case class NeighborNodeInfo(accessorName: String, node: AbstractNodeType, cardinality: Cardinality)
+
 case class NeighborInfo(edge: EdgeType, nodeInfos: Seq[NeighborNodeInfo], offsetPosition: Int) {
   lazy val deriveNeighborNodeType: String = {
     val nodeInfosSet = nodeInfos.map(_.node).toSet
-    if (nodeInfosSet.size == 1) nodeInfosSet.head.className
-    else "StoredNode"
+    val defaultNodeType = "StoredNode"
+
+    if (nodeInfosSet.size == 1) {
+      nodeInfosSet.head.className
+    } else if (nodeInfosSet.size > 1) {
+      /** try to find common supertype. this is nontrivial and we're probably missing a few cases.
+       * trying to at least keep it deterministic... */
+//      def deriveCommonSuperType(nodeTypes: Set[AbstractNodeType]): Option[AbstractNodeType] =
+//      Helpers.deriveCommonSuperType(nodeInfosSet).map(_.className).getOrElse(defaultNodeType)
+      "TODO"
+
+    } else {
+      defaultNodeType
+    }
   }
 }
 

--- a/src/main/scala/overflowdb/schema/Schema.scala
+++ b/src/main/scala/overflowdb/schema/Schema.scala
@@ -148,11 +148,11 @@ object Constant {
     new Constant(name, value, valueType, stringToOption(comment), schemaInfo)
 }
 
-case class NeighborNodeInfo(accessorName: String, className: String, cardinality: Cardinality)
+case class NeighborNodeInfo(accessorName: String, node: AbstractNodeType, cardinality: Cardinality)
 case class NeighborInfo(edge: EdgeType, nodeInfos: Seq[NeighborNodeInfo], offsetPosition: Int) {
   lazy val deriveNeighborNodeType: String = {
-    val nodeInfosSet = nodeInfos.map(_.className).toSet
-    if (nodeInfosSet.size == 1) nodeInfosSet.head
+    val nodeInfosSet = nodeInfos.map(_.node).toSet
+    if (nodeInfosSet.size == 1) nodeInfosSet.head.className
     else "StoredNode"
   }
 }

--- a/src/main/scala/overflowdb/schema/Schema.scala
+++ b/src/main/scala/overflowdb/schema/Schema.scala
@@ -153,21 +153,9 @@ case class NeighborNodeInfo(accessorName: String, node: AbstractNodeType, cardin
 
 case class NeighborInfo(edge: EdgeType, nodeInfos: Seq[NeighborNodeInfo], offsetPosition: Int) {
   lazy val deriveNeighborNodeType: String = {
-    val nodeInfosSet = nodeInfos.map(_.node).toSet
-    val defaultNodeType = "StoredNode"
-
-    if (nodeInfosSet.size == 1) {
-      nodeInfosSet.head.className
-    } else if (nodeInfosSet.size > 1) {
-      /** try to find common supertype. this is nontrivial and we're probably missing a few cases.
-       * trying to at least keep it deterministic... */
-//      def deriveCommonSuperType(nodeTypes: Set[AbstractNodeType]): Option[AbstractNodeType] =
-//      Helpers.deriveCommonSuperType(nodeInfosSet).map(_.className).getOrElse(defaultNodeType)
-      "TODO"
-
-    } else {
-      defaultNodeType
-    }
+    deriveCommonSuperType(nodeInfos.map(_.node).toSet)
+      .map(_.className)
+      .getOrElse("StoredNode")
   }
 }
 

--- a/src/main/scala/overflowdb/schema/testschema4/TestSchema4.scala
+++ b/src/main/scala/overflowdb/schema/testschema4/TestSchema4.scala
@@ -1,0 +1,28 @@
+package overflowdb.schema.testschema4
+
+import overflowdb.codegen.CodeGen
+import overflowdb.schema.{SchemaBuilder, SchemaInfo}
+
+import java.io.File
+
+// TODO create integration test from this
+object TestSchema4 extends App {
+  val builder = new SchemaBuilder("io.shiftleft.codepropertygraph.generated")
+
+  implicit val schemaInfo = SchemaInfo.forClass(getClass)
+
+  val edge1 = builder.addEdgeType("EDGE_1")
+  val rootNode1 = builder.addNodeBaseType("ROOT_NODE_1")
+  val rootNode2 = builder.addNodeBaseType("ROOT_NODE_2")
+  rootNode1.addOutEdge(edge1, inNode = rootNode2)
+
+  val node1 = builder.addNodeType("NODE_1").extendz(rootNode1)
+  val node2 = builder.addNodeType("NODE_2").extendz(rootNode2)
+
+  val schema = builder.build
+  // make some brief verifications
+  val node1Final = schema.nodeTypes.find(_.name == node1.name).get
+  assert(node1Final.outEdges.size == 1)
+
+  new CodeGen(schema).run(new File("target"))
+}

--- a/src/test/scala/overflowdb/schema/SchemaTest.scala
+++ b/src/test/scala/overflowdb/schema/SchemaTest.scala
@@ -5,15 +5,19 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class SchemaTest extends AnyWordSpec with Matchers {
 
-  "NeighborInfo.deriveNeighborNodeType" should {
+  "NeighborInfo.deriveNeighborNodeType" when {
     val defaultNeighborNodeType = "StoredNode"
 
-    "for no (known) neighbor" in {
+    "having no (known) neighbor" in {
       neighborInfoWith(Seq.empty).deriveNeighborNodeType shouldBe defaultNeighborNodeType
     }
 
-    "for one neighbor" in {
+    "having one neighbor" in {
       neighborInfoWith(Seq("Foo")).deriveNeighborNodeType shouldBe "Foo"
+    }
+
+    "having multiple neighbors with same type" in {
+      neighborInfoWith(Seq("Foo", "Foo")).deriveNeighborNodeType shouldBe "Foo"
     }
 
     def neighborInfoWith(nodeClassnames: Seq[String]): NeighborInfo =

--- a/src/test/scala/overflowdb/schema/SchemaTest.scala
+++ b/src/test/scala/overflowdb/schema/SchemaTest.scala
@@ -1,0 +1,27 @@
+package overflowdb.schema
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class SchemaTest extends AnyWordSpec with Matchers {
+
+  "NeighborInfo.deriveNeighborNodeType" should {
+    val defaultNeighborNodeType = "StoredNode"
+
+    def neighborInfoWith(nodeInfos: Seq[NeighborNodeInfo]): NeighborInfo =
+       NeighborInfo(edge = null, nodeInfos, offsetPosition = 0)
+
+
+    "for no (known) neighbor" in {
+      neighborInfoWith(nodeInfos = Seq.empty).deriveNeighborNodeType shouldBe defaultNeighborNodeType
+    }
+
+    "for one neighbor" in {
+      val nodeInfos = Seq(
+        NeighborNodeInfo(accessorName = null, className = "Foo", cardinality = null)
+      )
+      neighborInfoWith(nodeInfos).deriveNeighborNodeType shouldBe "Foo"
+    }
+  }
+
+}

--- a/src/test/scala/overflowdb/schema/SchemaTest.scala
+++ b/src/test/scala/overflowdb/schema/SchemaTest.scala
@@ -39,7 +39,7 @@ class SchemaTest extends AnyWordSpec with Matchers {
       // more complex hierarchy: multiple levels
       val baseNodeAExt = new NodeBaseType(name = "BASE_A_EXT", comment = None, SchemaInfo.Unknown).extendz(baseNodeA)
       val nodeAExt1 = new NodeType(name = "A_EXT_1", comment = None, SchemaInfo.Unknown).extendz(baseNodeAExt)
-      neighborInfoWith(Seq(nodeA1, nodeAExt1, nodeAExt1, baseNodeAExt, baseNodeA)).deriveNeighborNodeType shouldBe baseNodeA.className
+      neighborInfoWith(Seq(nodeA1, nodeAExt1, baseNodeAExt, baseNodeA)).deriveNeighborNodeType shouldBe baseNodeA.className
     }
 
     def neighborInfoWith(nodes: Seq[AbstractNodeType]): NeighborInfo =

--- a/src/test/scala/overflowdb/schema/SchemaTest.scala
+++ b/src/test/scala/overflowdb/schema/SchemaTest.scala
@@ -8,20 +8,19 @@ class SchemaTest extends AnyWordSpec with Matchers {
   "NeighborInfo.deriveNeighborNodeType" should {
     val defaultNeighborNodeType = "StoredNode"
 
-    def neighborInfoWith(nodeInfos: Seq[NeighborNodeInfo]): NeighborInfo =
-       NeighborInfo(edge = null, nodeInfos, offsetPosition = 0)
-
-
     "for no (known) neighbor" in {
-      neighborInfoWith(nodeInfos = Seq.empty).deriveNeighborNodeType shouldBe defaultNeighborNodeType
+      neighborInfoWith(Seq.empty).deriveNeighborNodeType shouldBe defaultNeighborNodeType
     }
 
     "for one neighbor" in {
-      val nodeInfos = Seq(
-        NeighborNodeInfo(accessorName = null, className = "Foo", cardinality = null)
-      )
-      neighborInfoWith(nodeInfos).deriveNeighborNodeType shouldBe "Foo"
+      neighborInfoWith(Seq("Foo")).deriveNeighborNodeType shouldBe "Foo"
     }
+
+    def neighborInfoWith(nodeClassnames: Seq[String]): NeighborInfo =
+      NeighborInfo(
+        edge = null,
+        nodeClassnames.map(c => NeighborNodeInfo(accessorName = null, className = c, cardinality = null)),
+        offsetPosition = 0)
   }
 
 }

--- a/src/test/scala/overflowdb/schema/SchemaTest.scala
+++ b/src/test/scala/overflowdb/schema/SchemaTest.scala
@@ -8,8 +8,9 @@ class SchemaTest extends AnyWordSpec with Matchers {
   "NeighborInfo.deriveNeighborNodeType" when {
     val defaultNeighborNodeType = "StoredNode"
     val baseNodeA = new NodeBaseType(name = "BASE_A", comment = None, SchemaInfo.Unknown)
-    val baseNodeB = new NodeBaseType(name = "BASE_B", comment = None, SchemaInfo.Unknown)
     val nodeA1 = new NodeType(name = "A1", comment = None, SchemaInfo.Unknown).extendz(baseNodeA)
+    val nodeA2 = new NodeType(name = "A2", comment = None, SchemaInfo.Unknown).extendz(baseNodeA)
+    val baseNodeB = new NodeBaseType(name = "BASE_B", comment = None, SchemaInfo.Unknown)
     val nodeB2 = new NodeType(name = "B1", comment = None, SchemaInfo.Unknown).extendz(baseNodeB)
 
     "having no (known) neighbor" in {
@@ -29,6 +30,16 @@ class SchemaTest extends AnyWordSpec with Matchers {
     "having different, unrelated neighbors" in {
       neighborInfoWith(Seq(nodeA1, nodeB2)).deriveNeighborNodeType shouldBe defaultNeighborNodeType
       neighborInfoWith(Seq(baseNodeA, baseNodeB)).deriveNeighborNodeType shouldBe defaultNeighborNodeType
+    }
+
+    "having multiple neighbors with same base type" in {
+      neighborInfoWith(Seq(nodeA1, nodeA2)).deriveNeighborNodeType shouldBe baseNodeA.className
+      neighborInfoWith(Seq(nodeA1, baseNodeA)).deriveNeighborNodeType shouldBe baseNodeA.className
+
+      // more complex hierarchy: multiple levels
+      val baseNodeAExt = new NodeBaseType(name = "BASE_A_EXT", comment = None, SchemaInfo.Unknown).extendz(baseNodeA)
+      val nodeAExt1 = new NodeType(name = "A_EXT_1", comment = None, SchemaInfo.Unknown).extendz(baseNodeAExt)
+      neighborInfoWith(Seq(nodeA1, nodeAExt1, nodeAExt1, baseNodeAExt, baseNodeA)).deriveNeighborNodeType shouldBe baseNodeA.className
     }
 
     def neighborInfoWith(nodes: Seq[AbstractNodeType]): NeighborInfo =

--- a/src/test/scala/overflowdb/schema/SchemaTest.scala
+++ b/src/test/scala/overflowdb/schema/SchemaTest.scala
@@ -7,8 +7,10 @@ class SchemaTest extends AnyWordSpec with Matchers {
 
   "NeighborInfo.deriveNeighborNodeType" when {
     val defaultNeighborNodeType = "StoredNode"
-    val nodeA1 = new NodeType(name = "A1", comment = None, SchemaInfo.Unknown)
-    val nodeB2 = new NodeType(name = "B1", comment = None, SchemaInfo.Unknown)
+    val baseNodeA = new NodeBaseType(name = "BASE_A", comment = None, SchemaInfo.Unknown)
+    val baseNodeB = new NodeBaseType(name = "BASE_B", comment = None, SchemaInfo.Unknown)
+    val nodeA1 = new NodeType(name = "A1", comment = None, SchemaInfo.Unknown).extendz(baseNodeA)
+    val nodeB2 = new NodeType(name = "B1", comment = None, SchemaInfo.Unknown).extendz(baseNodeB)
 
     "having no (known) neighbor" in {
       neighborInfoWith(Seq.empty).deriveNeighborNodeType shouldBe defaultNeighborNodeType
@@ -16,14 +18,17 @@ class SchemaTest extends AnyWordSpec with Matchers {
 
     "having one neighbor" in {
       neighborInfoWith(Seq(nodeA1)).deriveNeighborNodeType shouldBe nodeA1.className
+      neighborInfoWith(Seq(baseNodeA)).deriveNeighborNodeType shouldBe baseNodeA.className
     }
 
     "having multiple neighbors with same type (e.g. different edges to same node type)" in {
       neighborInfoWith(Seq(nodeA1, nodeA1)).deriveNeighborNodeType shouldBe nodeA1.className
+      neighborInfoWith(Seq(baseNodeA, baseNodeA)).deriveNeighborNodeType shouldBe baseNodeA.className
     }
 
     "having different, unrelated neighbors" in {
       neighborInfoWith(Seq(nodeA1, nodeB2)).deriveNeighborNodeType shouldBe defaultNeighborNodeType
+      neighborInfoWith(Seq(baseNodeA, baseNodeB)).deriveNeighborNodeType shouldBe defaultNeighborNodeType
     }
 
     def neighborInfoWith(nodes: Seq[AbstractNodeType]): NeighborInfo =

--- a/src/test/scala/overflowdb/schema/SchemaTest.scala
+++ b/src/test/scala/overflowdb/schema/SchemaTest.scala
@@ -7,23 +7,29 @@ class SchemaTest extends AnyWordSpec with Matchers {
 
   "NeighborInfo.deriveNeighborNodeType" when {
     val defaultNeighborNodeType = "StoredNode"
+    val nodeA1 = new NodeType(name = "A1", comment = None, SchemaInfo.Unknown)
+    val nodeB2 = new NodeType(name = "B1", comment = None, SchemaInfo.Unknown)
 
     "having no (known) neighbor" in {
       neighborInfoWith(Seq.empty).deriveNeighborNodeType shouldBe defaultNeighborNodeType
     }
 
     "having one neighbor" in {
-      neighborInfoWith(Seq("Foo")).deriveNeighborNodeType shouldBe "Foo"
+      neighborInfoWith(Seq(nodeA1)).deriveNeighborNodeType shouldBe nodeA1.className
     }
 
-    "having multiple neighbors with same type" in {
-      neighborInfoWith(Seq("Foo", "Foo")).deriveNeighborNodeType shouldBe "Foo"
+    "having multiple neighbors with same type (e.g. different edges to same node type)" in {
+      neighborInfoWith(Seq(nodeA1, nodeA1)).deriveNeighborNodeType shouldBe nodeA1.className
     }
 
-    def neighborInfoWith(nodeClassnames: Seq[String]): NeighborInfo =
+    "having different, unrelated neighbors" in {
+      neighborInfoWith(Seq(nodeA1, nodeB2)).deriveNeighborNodeType shouldBe defaultNeighborNodeType
+    }
+
+    def neighborInfoWith(nodes: Seq[AbstractNodeType]): NeighborInfo =
       NeighborInfo(
         edge = null,
-        nodeClassnames.map(c => NeighborNodeInfo(accessorName = null, className = c, cardinality = null)),
+        nodes.map(node => NeighborNodeInfo(accessorName = null, node, cardinality = null)),
         offsetPosition = 0)
   }
 

--- a/src/test/scala/overflowdb/schema/SchemaTest.scala
+++ b/src/test/scala/overflowdb/schema/SchemaTest.scala
@@ -45,7 +45,7 @@ class SchemaTest extends AnyWordSpec with Matchers {
     def neighborInfoWith(nodes: Seq[AbstractNodeType]): NeighborInfo =
       NeighborInfo(
         edge = null,
-        nodes.map(node => NeighborNodeInfo(accessorName = null, node, cardinality = null)),
+        nodes.map(node => NeighborNodeInfo(accessorName = null, node, cardinality = null, isInherited = false)),
         offsetPosition = 0)
   }
 


### PR DESCRIPTION
* define edges on node base types, e.g.
```
val rootNode1 = builder.addNodeBaseType("ROOT_NODE_1")
val rootNode2 = builder.addNodeBaseType("ROOT_NODE_2")
rootNode1.addOutEdge(edge1, inNode = rootNode2)
```

* additional type-specific neighbor accessors, e.g. `def refOut: Traversal[TypeDecl]` - neighbor node type is derived, fallback is StoredNode