### PR TITLE
adaptations for edge cases when defining Edges on NodeBaseTypes

### DIFF
--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1052,7 +1052,7 @@ class CodeGen(schema: Schema) {
         val nodeDelegators = neighborInfo.nodeInfos.collect {
           case NeighborNodeInfoForNode(accessorNameForNode, neighborNode, cardinality, isInherited) if !isInherited =>
             val returnType = fullScalaType(neighborNode, cardinality)
-            s"def $accessorNameForNode: $returnType = get().$accessorNameForNode"
+            s"def _$accessorNameForNode: $returnType = get()._$accessorNameForNode"
         }.mkString("\n")
 
         s"""def $edgeAccessorName = get().$edgeAccessorName
@@ -1111,7 +1111,7 @@ class CodeGen(schema: Schema) {
               case Cardinality.ZeroOrOne => s".nextOption()"
               case _ => ""
             }
-            s"def $accessorNameForNode: $returnType = $edgeAccessorName.collectAll[${neighborNode.className}]$appendix"
+            s"def _$accessorNameForNode: $returnType = $edgeAccessorName.collectAll[${neighborNode.className}]$appendix"
         }.mkString("\n")
 
         s"""def $edgeAccessorName: Traversal[$neighborType] = Traversal(createAdjacentNodeIteratorByOffSet[$neighborType]($offsetPosition))

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -762,19 +762,21 @@ class CodeGen(schema: Schema) {
         case class NeighborContext(adjacentNode: AdjacentNode, isInherited: Boolean)
 
         def neighborContexts(adjacentNodes: AbstractNodeType => Seq[AdjacentNode]): Seq[NeighborContext] = {
-          val inherited: Seq[AdjacentNode] = nodeType.extendzRecursively.flatMap(adjacentNodes)
-          val direct: Seq[AdjacentNode] = adjacentNodes(nodeType).filter(inherited.contains)
-          // TODO idea: just filter out the inherited ones here?
-          direct.map(NeighborContext(_, false)) ++ inherited.map(NeighborContext(_, true))
-//          adjacentNodes(nodeType).map(NeighborContext(_, false)) ++
-//            nodeType.extendzRecursively.flatMap(adjacentNodes).map(NeighborContext(_, true))
+          val inherited: Seq[AdjacentNode] = nodeType.extendzRecursively.flatMap(adjacentNodes).distinct
+          val inheritedWithoutCardinality: Set[(EdgeType, AbstractNodeType)] =
+            inherited.map { case AdjacentNode(viaEdge, neighbor, _) => (viaEdge, neighbor) }.toSet
+
+          val direct: Seq[NeighborContext] = adjacentNodes(nodeType).map { adjacentNode =>
+            val isInherited = inheritedWithoutCardinality.contains((adjacentNode.viaEdge, adjacentNode.neighbor))
+            NeighborContext(adjacentNode, isInherited)
+          }
+          val inherited2: Seq[NeighborContext] = inherited.map(NeighborContext(_, true))
+          (direct ++ inherited2).distinct
         }
 
         def createNeighborInfos(neighborContexts: Seq[NeighborContext], direction: Direction.Value): Seq[NeighborInfoForEdge] = {
           neighborContexts.groupBy(_.adjacentNode.viaEdge).map { case (edgeType, neighborContexts) =>
             val neighborInfoForNodes = neighborContexts.map { case NeighborContext(adjacentNode, isInherited) =>
-              // TODO derive that for both FieldIdentifier and Call, the CFG edge is inherited
-//              println(nodeType)
               NeighborInfoForNode(adjacentNode.neighbor, edgeType, direction, adjacentNode.cardinality, isInherited)
             }
             NeighborInfoForEdge(edgeType, neighborInfoForNodes, nextOffsetPos)

--- a/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -711,7 +711,7 @@ class CodeGen(schema: Schema) {
               }
               s"def $accessorName: ${fullScalaType(neighbor, cardinality)} = $edgeAccessorName.collectAll[${neighbor.className}]$appendix"
             }
-          }.mkString("\n\n")
+          }.distinct.mkString("\n\n")
 
           s"""$genericEdgeAccessor
              |

--- a/src/test/scala/overflowdb/schema/SchemaTest.scala
+++ b/src/test/scala/overflowdb/schema/SchemaTest.scala
@@ -45,7 +45,7 @@ class SchemaTest extends AnyWordSpec with Matchers {
     def neighborInfoWith(nodes: Seq[AbstractNodeType]): NeighborInfoForEdge =
       NeighborInfoForEdge(
         edge = null,
-        nodes.map(node => NeighborNodeInfoForNode(accessorName = null, node, cardinality = null, isInherited = false)),
+        nodes.map(node => NeighborInfoForNode(neighborNode = node, edge = null, direction = null, cardinality = null, isInherited = false)),
         offsetPosition = 0)
   }
 


### PR DESCRIPTION
* deduplicate neighbor accessors
* handle edge cases where an edge is defined on the node base type and then again on a subtype, with different caridnalities