### PR TITLE
cleanup 'warnings for duplicate properties'

### DIFF
--- a/codegen/src/main/scala/overflowdb/schema/Schema.scala
+++ b/codegen/src/main/scala/overflowdb/schema/Schema.scala
@@ -47,7 +47,7 @@ abstract class AbstractNodeType(val name: String, val comment: Option[String], v
      * defined in one of the parents */
     for {
       property <- _properties
-      baseType <- _extendz
+      baseType <- extendzRecursively
       if baseType.properties.contains(property)
     } println(s"[info]: $this wouldn't need to have $property added explicitly - $baseType already brings it in")
 

--- a/codegen/src/main/scala/overflowdb/schema/Schema.scala
+++ b/codegen/src/main/scala/overflowdb/schema/Schema.scala
@@ -43,14 +43,6 @@ abstract class AbstractNodeType(val name: String, val comment: Option[String], v
   def subtypes(allNodes: Set[AbstractNodeType]): Set[AbstractNodeType]
 
   override def properties: Seq[Property] = {
-    /* only to provide feedback for potential schema optimisation: no need to redefine properties if they are already
-     * defined in one of the parents */
-    for {
-      property <- _properties
-      baseType <- extendzRecursively
-      if baseType.properties.contains(property)
-    } println(s"[info]: $this wouldn't need to have $property added explicitly - $baseType already brings it in")
-
     (_properties ++ _extendz.flatMap(_.properties)).toSeq.sortBy(_.name.toLowerCase)
   }
 


### PR DESCRIPTION
* involve all base types in search for duplicate properties
* deduplicate warnings
* refactor into separate step, call explicitly

new style output:
``` 2 warnings found:
[info]: NodeType(FILE) wouldn't need to have Property(ORDER) added
explicitly - NodeBaseType(AST_NODE) already brings it in
[info]: NodeType(NAMESPACE_BLOCK) wouldn't need to have Property(ORDER)
added explicitly - NodeBaseType(AST_NODE) already brings it in
```