### PR TITLE
allow to configure codegen to not warn about certain properties duplicate definitions

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -12,6 +12,12 @@ class CodeGen(schema: Schema) {
   val basePackage = schema.basePackage
   val nodesPackage = s"$basePackage.nodes"
   val edgesPackage = s"$basePackage.edges"
+  private val noWarnList: mutable.Set[(AbstractNodeType, Property)] = mutable.Set.empty
+
+  def dontWarnForDuplicateProperty(nodeType: AbstractNodeType, property: Property): CodeGen = {
+    noWarnList.addOne((nodeType, property))
+    this
+  }
 
   def run(outputDir: java.io.File): Seq[java.io.File] = {
     warnForDuplicatePropertyDefinitions()
@@ -28,7 +34,7 @@ class CodeGen(schema: Schema) {
       nodeType <- schema.allNodeTypes
       property <- nodeType.properties
       baseType <- nodeType.extendzRecursively
-      if baseType.properties.contains(property)
+      if baseType.properties.contains(property) && !noWarnList.contains((nodeType, property))
     } yield s"[info]: $nodeType wouldn't need to have $property added explicitly - $baseType already brings it in"
 
     println(s"${warnings.size} warnings found:")

--- a/codegen/src/main/scala/overflowdb/schema/testschema1/TestSchema1.scala
+++ b/codegen/src/main/scala/overflowdb/schema/testschema1/TestSchema1.scala
@@ -238,5 +238,7 @@ object TestSchema1 extends App {
     )
   )
 
-  new CodeGen(builder.build).run(new File("target"))
+  new CodeGen(builder.build)
+    .dontWarnForDuplicateProperty(file, order)
+    .run(new File("target"))
 }


### PR DESCRIPTION
example use case:
* schema is defined in two codebases: base and extension
* base defines a node type N1 with property P1
* extension defines a base node type BN1 which extends N1 and also has
  property P1