### PR TITLE
don't rely on variable name being there

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -796,7 +796,7 @@ class CodeGen(schema: Schema) {
     def generateNodeSource(nodeType: NodeType) = {
       val properties = nodeType.propertiesRecursively
 
-      val propertyNames = properties.map(_.name) ++ nodeType.containedNodes.map(_.localName)
+      val propertyNames = (properties.map(_.name) ++ nodeType.containedNodes.map(_.localName)).distinct
       val propertyNameDefs = propertyNames.map { name =>
         s"""val ${camelCaseCaps(name)} = "$name" """
       }.mkString("\n|    ")

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -958,27 +958,22 @@ class CodeGen(schema: Schema) {
       }
 
       val fromNew = {
+        val newNodeCasted = s"newNode.asInstanceOf[New${nodeType.className}]"
+
         val initKeysImpl = {
-          if (properties.nonEmpty) {
-            val lines = properties.map { key: Property =>
-              val memberName = camelCase(key.name)
-              key.cardinality match {
-                case Cardinality.One =>
-                  s"""   this._$memberName = other.$memberName""".stripMargin
-                case Cardinality.ZeroOrOne =>
-                  s"""   this._$memberName = if(other.$memberName != null) other.$memberName else None""".stripMargin
-                case Cardinality.List =>
-                  s"""   this._$memberName = if(other.$memberName != null) other.$memberName else Nil""".stripMargin
-                case Cardinality.ISeq => ???
-              }
+          val lines = properties.map { key: Property =>
+            val memberName = camelCase(key.name)
+            key.cardinality match {
+              case Cardinality.One =>
+                s"""   this._$memberName = $newNodeCasted.$memberName""".stripMargin
+              case Cardinality.ZeroOrOne =>
+                s"""   this._$memberName = if ($newNodeCasted.$memberName != null) $newNodeCasted.$memberName else None""".stripMargin
+              case Cardinality.List =>
+                s"""   this._$memberName = if ($newNodeCasted.$memberName != null) $newNodeCasted.$memberName else Nil""".stripMargin
+              case Cardinality.ISeq => ???
             }
-            s"""//this will throw for bad types -- no need to check by hand, we don't have a better error message
-               |  val other = someNewNode.asInstanceOf[New${nodeType.className}]
-               |  ${lines.mkString("\n")}
-               |""".stripMargin
-          } else {
-            ""
           }
+          lines.mkString("\n")
         }
 
         val initRefsImpl = {
@@ -988,21 +983,21 @@ class CodeGen(schema: Schema) {
 
             containedNode.cardinality match {
               case Cardinality.One =>
-                s"""  this._$memberName = other.$memberName match {
+                s"""  this._$memberName = $newNodeCasted.$memberName match {
                    |    case null => null
                    |    case newNode: NewNode => mapping(newNode).asInstanceOf[$containedNodeType]
                    |    case oldNode: StoredNode => oldNode.asInstanceOf[$containedNodeType]
                    |    case _ => throw new MatchError("unreachable")
                    |  }""".stripMargin
               case Cardinality.ZeroOrOne =>
-                s"""  this._$memberName = other.$memberName match {
+                s"""  this._$memberName = $newNodeCasted.$memberName match {
                    |    case null | None => None
                    |    case Some(newNode:NewNode) => Some(mapping(newNode).asInstanceOf[$containedNodeType])
                    |    case Some(oldNode:StoredNode) => Some(oldNode.asInstanceOf[$containedNodeType])
                    |    case _ => throw new MatchError("unreachable")
                    |  }""".stripMargin
               case Cardinality.List => // need java list, e.g. for NodeSerializer
-                s"""  this._$memberName = if(other.$memberName == null) Nil else other.$memberName.map { nodeRef => nodeRef match {
+                s"""  this._$memberName = if($newNodeCasted.$memberName == null) Nil else $newNodeCasted.$memberName.map { nodeRef => nodeRef match {
                    |    case null => throw new NullPointerException("Nullpointers forbidden in contained nodes")
                    |    case newNode:NewNode => mapping(newNode).asInstanceOf[$containedNodeType]
                    |    case oldNode:StoredNode => oldNode.asInstanceOf[$containedNodeType]
@@ -1010,8 +1005,8 @@ class CodeGen(schema: Schema) {
                    |  }}""".stripMargin
               case Cardinality.ISeq =>
                 s"""{
-                   |  val arr = if(other.$memberName == null || other.$memberName.isEmpty) null
-                   |    else other.$memberName.map { nodeRef => nodeRef match {
+                   |  val arr = if($newNodeCasted.$memberName == null || $newNodeCasted.$memberName.isEmpty) null
+                   |    else $newNodeCasted.$memberName.map { nodeRef => nodeRef match {
                    |      case null => throw new NullPointerException("Nullpointers forbidden in contained nodes")
                    |      case newNode:NewNode => mapping(newNode).asInstanceOf[$containedNodeType]
                    |      case oldNode:StoredNode => oldNode.asInstanceOf[$containedNodeType]
@@ -1026,10 +1021,10 @@ class CodeGen(schema: Schema) {
         }.mkString("\n\n")
 
         val registerFullName = if(!properties.map{_.name}.contains("FULL_NAME")) "" else {
-          s"""  graph.indexManager.putIfIndexed("FULL_NAME", other.fullName, this.ref)"""
+          s"""  graph.indexManager.putIfIndexed("FULL_NAME", $newNodeCasted.fullName, this.ref)"""
         }
 
-        s"""override def fromNewNode(someNewNode: NewNode, mapping: NewNode => StoredNode):Unit = {
+        s"""override def fromNewNode(newNode: NewNode, mapping: NewNode => StoredNode):Unit = {
            |$initKeysImpl
            |$initRefsImpl
            |$registerFullName

--- a/codegen/src/main/scala/overflowdb/schema/Schema.scala
+++ b/codegen/src/main/scala/overflowdb/schema/Schema.scala
@@ -43,7 +43,7 @@ abstract class AbstractNodeType(val name: String, val comment: Option[String], v
   def subtypes(allNodes: Set[AbstractNodeType]): Set[AbstractNodeType]
 
   def propertiesRecursively: Seq[Property] = {
-    (properties ++ _extendz.flatMap(_.properties)).sortBy(_.name.toLowerCase)
+    (properties ++ _extendz.flatMap(_.propertiesRecursively)).sortBy(_.name.toLowerCase)
   }
 
   def extendz(additional: NodeBaseType*): this.type = {

--- a/codegen/src/main/scala/overflowdb/schema/Schema.scala
+++ b/codegen/src/main/scala/overflowdb/schema/Schema.scala
@@ -42,10 +42,15 @@ abstract class AbstractNodeType(val name: String, val comment: Option[String], v
   /** all node types that extend this node */
   def subtypes(allNodes: Set[AbstractNodeType]): Set[AbstractNodeType]
 
-  def propertiesRecursively: Seq[Property] = {
+
+  /** properties (including potentially inherited properties) */
+  override def properties: Seq[Property] = {
     val entireClassHierarchy = this +: extendzRecursively
-    entireClassHierarchy.flatMap(_.properties).distinct.sortBy(_.name.toLowerCase)
+    entireClassHierarchy.flatMap(_.propertiesWithoutInheritance).distinct.sortBy(_.name.toLowerCase)
   }
+
+  def propertiesWithoutInheritance: Seq[Property] =
+    _properties.toSeq.sortBy(_.name.toLowerCase)
 
   def extendz(additional: NodeBaseType*): this.type = {
     additional.foreach(_extendz.add)
@@ -140,6 +145,10 @@ object Cardinality {
 class EdgeType(val name: String, val comment: Option[String], val schemaInfo: SchemaInfo)
   extends HasClassName with HasProperties with HasOptionalProtoId with HasSchemaInfo {
   override def toString = s"EdgeType($name)"
+
+  /** properties (including potentially inherited properties) */
+  def properties: Seq[Property] =
+    _properties.toSeq.sortBy(_.name.toLowerCase)
 }
 
 class Property(val name: String,
@@ -241,7 +250,8 @@ trait HasProperties {
     this
   }
 
-  def properties: Seq[Property] = _properties.toSeq.sortBy(_.name.toLowerCase)
+  /** properties (including potentially inherited properties) */
+  def properties: Seq[Property]
 }
 
 trait HasOptionalProtoId {

--- a/codegen/src/main/scala/overflowdb/schema/Schema.scala
+++ b/codegen/src/main/scala/overflowdb/schema/Schema.scala
@@ -43,7 +43,8 @@ abstract class AbstractNodeType(val name: String, val comment: Option[String], v
   def subtypes(allNodes: Set[AbstractNodeType]): Set[AbstractNodeType]
 
   def propertiesRecursively: Seq[Property] = {
-    (properties ++ _extendz.flatMap(_.propertiesRecursively)).sortBy(_.name.toLowerCase)
+    val entireClassHierarchy = this +: extendzRecursively
+    entireClassHierarchy.flatMap(_.properties).distinct.sortBy(_.name.toLowerCase)
   }
 
   def extendz(additional: NodeBaseType*): this.type = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "2.0.11")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")


### PR DESCRIPTION
* it's generated code, so we can be longer here
* old style relied on `val other = ...` but that led to warnings in some situations