### PR TITLE
use less-precise traversal kind for base node accessors

### DIFF
--- a/integration-tests/schemas/src/main/scala/CodegenForAllSchemas.scala
+++ b/integration-tests/schemas/src/main/scala/CodegenForAllSchemas.scala
@@ -11,6 +11,7 @@ object CodegenForAllSchemas extends App {
     new TestSchema02,
     new TestSchema03a,
     new TestSchema03b,
+    new TestSchema03c,
   ).foreach { schema =>
     new CodeGen(schema.instance).run(outputDir)
   }

--- a/integration-tests/schemas/src/main/scala/TestSchema03.scala
+++ b/integration-tests/schemas/src/main/scala/TestSchema03.scala
@@ -23,15 +23,13 @@ class TestSchema03b extends TestSchema {
 
 class TestSchema03c extends TestSchema {
   val ast = builder.addEdgeType(name = "AST")
-  val astNode = builder.addNodeBaseType(name = "AST_NODE")
-  val expression = builder.addNodeBaseType(name = "EXPRESSION").extendz(astNode)
-  val instruction = builder.addNodeBaseType(name = "INSTRUCTION").extendz(expression)
+  val expression = builder.addNodeBaseType(name = "EXPRESSION")
 
   val typeRef = builder.addNodeType(name = "TYPE_REF")
     .extendz(expression)
     .addOutEdge(edge = ast, inNode = expression)
 
   val otherInstruction = builder.addNodeType(name = "OTHER_INSTRUCTION")
-    .extendz(instruction)
+    .extendz(expression)
     .addOutEdge(edge = ast, inNode = typeRef)
 }

--- a/integration-tests/schemas/src/main/scala/TestSchema03.scala
+++ b/integration-tests/schemas/src/main/scala/TestSchema03.scala
@@ -20,3 +20,18 @@ class TestSchema03b extends TestSchema {
   nodeExt2.addOutEdge(edge = edge2, inNode = abstractNode2)
   otherNode2.addOutEdge(edge = edge2, inNode = nodeExt2)
 }
+
+class TestSchema03c extends TestSchema {
+  val ast = builder.addEdgeType(name = "AST")
+  val astNode = builder.addNodeBaseType(name = "AST_NODE")
+  val expression = builder.addNodeBaseType(name = "EXPRESSION").extendz(astNode)
+  val instruction = builder.addNodeBaseType(name = "INSTRUCTION").extendz(expression)
+
+  val typeRef = builder.addNodeType(name = "TYPE_REF")
+    .extendz(expression)
+    .addOutEdge(edge = ast, inNode = expression)
+
+  val otherInstruction = builder.addNodeType(name = "OTHER_INSTRUCTION")
+    .extendz(instruction)
+    .addOutEdge(edge = ast, inNode = typeRef)
+}

--- a/integration-tests/schemas/src/main/scala/TestSchema03.scala
+++ b/integration-tests/schemas/src/main/scala/TestSchema03.scala
@@ -22,14 +22,14 @@ class TestSchema03b extends TestSchema {
 }
 
 class TestSchema03c extends TestSchema {
-  val ast = builder.addEdgeType(name = "AST")
-  val expression = builder.addNodeBaseType(name = "EXPRESSION")
+  val edge1 = builder.addEdgeType(name = "edge1")
+  val abstractNode = builder.addNodeBaseType(name = "ABSTRACT_NODE1")
 
-  val typeRef = builder.addNodeType(name = "TYPE_REF")
-    .extendz(expression)
-    .addOutEdge(edge = ast, inNode = expression)
+  val node1 = builder.addNodeType(name = "NODE1")
+    .extendz(abstractNode)
+    .addOutEdge(edge = edge1, inNode = abstractNode)
 
-  val otherInstruction = builder.addNodeType(name = "OTHER_INSTRUCTION")
-    .extendz(expression)
-    .addOutEdge(edge = ast, inNode = typeRef)
+  val node2 = builder.addNodeType(name = "NODE2")
+    .extendz(abstractNode)
+    .addOutEdge(edge = edge1, inNode = node1)
 }

--- a/integration-tests/tests/src/test/scala/Schema03Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema03Test.scala
@@ -24,5 +24,18 @@ class Schema03bTest {
   def edge2In: Traversal[StoredNode] = abstractNode2.edge2In
   def _abstractNode2ViaEdge2In: Traversal[AbstractNode2] = abstractNode2._abstractNode2ViaEdge2In
   def _nodeExt2ViaEdge2In: Traversal[NodeExt2] = abstractNode2._nodeExt2ViaEdge2In
+}
+
+class Schema03cTest {
+//  import testschema03c._
+//  import testschema03c.edges._
+//  import testschema03c.nodes._
+//  import testschema03c.traversal._
+//
+//  // just verifying that the following code compiles
+//  val abstractNode3: AbstractNode3 = ???
+//  def edge3In: Traversal[StoredNode] = abstractNode3.edge3In
+//  def _abstractNode3ViaEdge3In: Traversal[AbstractNode3] = abstractNode3._abstractNode3ViaEdge3In
+//  def _nodeExt3ViaEdge3In: Traversal[NodeExt3] = abstractNode3._nodeExt3ViaEdge3In
 
 }

--- a/integration-tests/tests/src/test/scala/Schema03Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema03Test.scala
@@ -27,6 +27,7 @@ class Schema03bTest {
 }
 
 class Schema03cTest {
+  // TODO
 //  import testschema03c._
 //  import testschema03c.edges._
 //  import testschema03c.nodes._

--- a/integration-tests/tests/src/test/scala/Schema03Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema03Test.scala
@@ -27,16 +27,18 @@ class Schema03bTest {
 }
 
 class Schema03cTest {
-  // TODO
-//  import testschema03c._
-//  import testschema03c.edges._
-//  import testschema03c.nodes._
-//  import testschema03c.traversal._
-//
-//  // just verifying that the following code compiles
-//  val abstractNode3: AbstractNode3 = ???
-//  def edge3In: Traversal[StoredNode] = abstractNode3.edge3In
-//  def _abstractNode3ViaEdge3In: Traversal[AbstractNode3] = abstractNode3._abstractNode3ViaEdge3In
-//  def _nodeExt3ViaEdge3In: Traversal[NodeExt3] = abstractNode3._nodeExt3ViaEdge3In
+  import testschema03c._
+  import testschema03c.edges._
+  import testschema03c.nodes._
+  import testschema03c.traversal._
 
+  // just verifying that the following code compiles
+  val abstractNode: AbstractNode1 = ???
+  def x0: Traversal[StoredNode] = abstractNode.edge1In
+
+  val node1: Node1 = ???
+  def x1: Traversal[AbstractNode1] = node1.edge1In
+
+  val node2: Node2 = ???
+  def x2: Traversal[Node1] = node2.edge1In
 }


### PR DESCRIPTION
Technically we should use the more precise types, since they are correct 
based on the schema. However the JVM doesn't allow these, at least not if
we use extension. Left a TODO to bring these back via extension methods.