### PR TITLE
overhaul of list property handling

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -281,7 +281,7 @@ class CodeGen(schema: Schema) {
                  |  property("$name") match {
                  |    case null => collection.immutable.ArraySeq.empty
                  |    case arr: Array[_] if arr.isEmpty => collection.immutable.ArraySeq.empty
-                 |    case arr: Array[Object] => scala.collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[$returnType]
+                 |    case arr: Array[_] => scala.collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[$returnType]
                  |    case iterable: IterableOnce[_] => iterable.iterator.to(IndexedSeq).asInstanceOf[$returnType]
                  |    case jList: java.util.List[_] => jList.asScala.to(IndexedSeq).asInstanceOf[$returnType]
                  |  }
@@ -951,7 +951,7 @@ class CodeGen(schema: Schema) {
                  |        case null => collection.immutable.ArraySeq.empty
                  |        case coll: IterableOnce[Any] if coll.isEmpty => collection.immutable.ArraySeq.empty
                  |        case arr: Array[_] if arr.isEmpty => collection.immutable.ArraySeq.empty
-                 |        case arr: Array[Object] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[$baseType]]
+                 |        case arr: Array[_] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[$baseType]]
                  |        case jCollection: java.lang.Iterable[_]  =>
                  |          if (jCollection.iterator.hasNext) {
                  |            collection.immutable.ArraySeq.unsafeWrapArray(

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -58,6 +58,7 @@ class CodeGen(schema: Schema) {
     val domainMain = baseDir.createChild(s"$domainShortName.scala").write(
       s"""package $basePackage;
          |
+         |import java.nio.file.{Path, Paths}
          |import overflowdb.traversal.help.TraversalHelp
          |import overflowdb.{Config, Graph}
          |
@@ -80,11 +81,14 @@ class CodeGen(schema: Schema) {
          |    * I.e. if you want to preserve state between sessions, just use this method to instantiate the $domainShortName and ensure to properly `close` it at the end.
          |    * @param path to the storage file, e.g. /home/user1/overflowdb.bin
          |    */
-         |  def withStorage(path: String): $domainShortName =
+         |  def withStorage(path: Path): $domainShortName =
          |    new $domainShortName(
          |      Graph.open(Config.withoutOverflow.withStorageLocation(path),
          |      nodes.Factories.allAsJava,
          |      edges.Factories.allAsJava))
+         |
+         |  def withStorage(path: String): $domainShortName =
+         |    withStorage(Paths.get(path))
          |
          |  private def emptyGraph: Graph =
          |    Graph.open(Config.withoutOverflow, nodes.Factories.allAsJava, edges.Factories.allAsJava)

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -577,8 +577,8 @@ class CodeGen(schema: Schema) {
               s"""properties.put("${key.name}", $memberName)"""
             case Cardinality.ZeroOrOne =>
               s"""$memberName.map { value => properties.put("${key.name}", value) }"""
-            case Cardinality.List | Cardinality.ISeq => // need java list, e.g. for NodeSerializer
-              s"""if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("${key.name}", $memberName.asJava) }"""
+            case Cardinality.List | Cardinality.ISeq =>
+              s"""if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("${key.name}", $memberName) }"""
           }
         }.mkString("\n")
 
@@ -590,8 +590,8 @@ class CodeGen(schema: Schema) {
                 s"""properties.put("$memberName", this._$memberName)"""
               case Cardinality.ZeroOrOne =>
                 s"""   $memberName.map { value => properties.put("$memberName", value) }"""
-              case Cardinality.List | Cardinality.ISeq => // need java list, e.g. for NodeSerializer
-                s"""  if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("$memberName", this.$memberName.asJava) }"""
+              case Cardinality.List | Cardinality.ISeq =>
+                s"""  if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("$memberName", this.$memberName) }"""
             }
           }
         }.mkString("\n")
@@ -614,8 +614,8 @@ class CodeGen(schema: Schema) {
               s"""if (!($isDefaultValueImpl)) { properties.put("${key.name}", $memberName) }"""
             case Cardinality.ZeroOrOne =>
               s"""$memberName.map { value => properties.put("${key.name}", value) }"""
-            case Cardinality.List | Cardinality.ISeq => // need java list, e.g. for NodeSerializer
-              s"""if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("${key.name}", $memberName.asJava) }"""
+            case Cardinality.List | Cardinality.ISeq =>
+              s"""if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("${key.name}", $memberName) }"""
           }
         }.mkString("\n")
 
@@ -628,8 +628,8 @@ class CodeGen(schema: Schema) {
                 s"""   if (!($isDefaultValueImpl)) { properties.put("$memberName", this._$memberName) }"""
               case Cardinality.ZeroOrOne =>
                 s"""   $memberName.map { value => properties.put("$memberName", value) }"""
-              case Cardinality.List | Cardinality.ISeq => // need java list, e.g. for NodeSerializer
-                s"""  if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("$memberName", this.$memberName.asJava) }"""
+              case Cardinality.List | Cardinality.ISeq =>
+                s"""  if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("$memberName", this.$memberName) }"""
             }
           }
         }.mkString("\n")
@@ -998,6 +998,13 @@ class CodeGen(schema: Schema) {
            |  override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[$classNameDb]
            |
            |  $propertyImpl
+           |
+           |  override def convertPropertyForStorage(property: Any): Any = {
+           |    property match {
+           |      case coll: IterableOnce[_] => coll.iterator.toBuffer.asJava
+           |      case other => other
+           |    }
+           |  }
            |
            |$updateSpecificPropertyImpl
            |

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -24,7 +24,11 @@ class CodeGen(schema: Schema) {
   def run(outputDir: java.io.File): Seq[java.io.File] = {
     warnForDuplicatePropertyDefinitions()
     val _outputDir = outputDir.toScala
-    val results = writeConstants(_outputDir) ++ writeEdgeFiles(_outputDir) ++ writeNodeFiles(_outputDir) ++ writeNodeTraversalFiles(_outputDir) :+ writeNewNodeFile(_outputDir)
+    val results = writeConstants(_outputDir) ++
+      writeEdgeFiles(_outputDir) ++
+      writeNodeFiles(_outputDir) ++
+      writeNodeTraversalFiles(_outputDir) :+
+      writeNewNodeFile(_outputDir)
     println(s"generated ${results.size} files in ${_outputDir}")
     results.map(_.toJava)
   }
@@ -612,7 +616,7 @@ class CodeGen(schema: Schema) {
            |}""".stripMargin
       }
 
-      val propertiesMapWithoutDefaultsImpl = {
+      val propertiesMapForStorageImpl = {
         import Property.Cardinality
         val putKeysImpl = properties.map { key =>
           val memberName = camelCase(key.name)
@@ -980,8 +984,8 @@ class CodeGen(schema: Schema) {
            |    $propertiesMapImpl
            |
            |  /** faster than the default implementation */
-           |  override def propertiesMapWithoutDefaults: java.util.Map[String, Any] =
-           |    $propertiesMapWithoutDefaultsImpl
+           |  override def propertiesMapForStorage: java.util.Map[String, Any] =
+           |    $propertiesMapForStorageImpl
            |
            |
            |  $neighborAccessors
@@ -1006,13 +1010,6 @@ class CodeGen(schema: Schema) {
            |  override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[$classNameDb]
            |
            |  $propertyImpl
-           |
-           |  override def convertPropertyForStorage(property: Any): Any = {
-           |    property match {
-           |      case coll: IterableOnce[_] => coll.iterator.toBuffer.asJava
-           |      case other => other
-           |    }
-           |  }
            |
            |$updateSpecificPropertyImpl
            |

--- a/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -103,10 +103,9 @@ object Helpers {
     import Property.Cardinality
     val valueType = typeFor(property)
     property.cardinality match {
-      case Cardinality.One(_)   => valueType
+      case Cardinality.One(_)    => valueType
       case Cardinality.ZeroOrOne => s"Option[$valueType]"
-      case Cardinality.List   => s"Seq[$valueType]"
-      case Cardinality.ISeq   => s"IndexedSeq[$valueType]"
+      case Cardinality.List      => s"IndexedSeq[$valueType]"
     }
   }
 
@@ -121,8 +120,7 @@ object Helpers {
     containedNode.cardinality match {
       case Property.Cardinality.ZeroOrOne => s"Option[$tpe]"
       case Property.Cardinality.One(_)    => tpe
-      case Property.Cardinality.List      => s"Seq[$tpe]"
-      case Property.Cardinality.ISeq => s"IndexedSeq[$tpe]"
+      case Property.Cardinality.List      => s"IndexedSeq[$tpe]"
     }
   }
 
@@ -130,8 +128,7 @@ object Helpers {
     val completeType = cardinality match {
       case Property.Cardinality.One(_)    => baseType
       case Property.Cardinality.ZeroOrOne => baseType
-      case Property.Cardinality.List      => s"Seq[$baseType]"
-      case Property.Cardinality.ISeq=> s"IndexedSeq[$baseType]"
+      case Property.Cardinality.List      => s"IndexedSeq[$baseType]"
     }
     s"""val ${camelCaseCaps(name)} = new overflowdb.PropertyKey[$completeType]("$name") """
   }

--- a/codegen/src/main/scala/overflowdb/schema/Schema.scala
+++ b/codegen/src/main/scala/overflowdb/schema/Schema.scala
@@ -187,12 +187,6 @@ class Property[A](val name: String,
     this
   }
 
-  /** make this an list property, using an indexed list for fast random access */
-  def asIndexedList(): Property[A] = {
-    _cardinality = Cardinality.ISeq
-    this
-  }
-
 }
 
 
@@ -219,7 +213,6 @@ object Property {
   object Cardinality {
     case object ZeroOrOne extends Cardinality
     case object List extends Cardinality
-    case object ISeq extends Cardinality
     case class One[A](default: Default[A]) extends Cardinality
   }
 

--- a/codegen/src/main/scala/overflowdb/schema/Schema.scala
+++ b/codegen/src/main/scala/overflowdb/schema/Schema.scala
@@ -9,7 +9,8 @@ import scala.collection.mutable
 /**
  * @param basePackage: specific for your domain, e.g. `com.example.mydomain`
  */
-class Schema(val basePackage: String,
+class Schema(val domainShortName: String,
+             val basePackage: String,
              val properties: Seq[Property[_]],
              val nodeBaseTypes: Seq[NodeBaseType],
              val nodeTypes: Seq[NodeType],

--- a/codegen/src/main/scala/overflowdb/schema/SchemaBuilder.scala
+++ b/codegen/src/main/scala/overflowdb/schema/SchemaBuilder.scala
@@ -5,7 +5,7 @@ import overflowdb.codegen.Helpers._
 import overflowdb.schema.Property.ValueType
 import scala.collection.mutable
 
-class SchemaBuilder(basePackage: String) {
+class SchemaBuilder(domainShortName: String, basePackage: String) {
   val properties = mutable.ListBuffer.empty[Property[_]]
   val nodeBaseTypes = mutable.ListBuffer.empty[NodeBaseType]
   val nodeTypes = mutable.ListBuffer.empty[NodeType]
@@ -64,6 +64,7 @@ class SchemaBuilder(basePackage: String) {
 
   def build: Schema = {
     val schema = new Schema(
+      domainShortName,
       basePackage,
       properties.sortBy(_.name.toLowerCase).toSeq,
       nodeBaseTypes.sortBy(_.name.toLowerCase).toSeq,

--- a/codegen/src/main/scala/overflowdb/schema/testschema1/TestSchema1.scala
+++ b/codegen/src/main/scala/overflowdb/schema/testschema1/TestSchema1.scala
@@ -8,7 +8,7 @@ import overflowdb.storage.ValueTypes
 
 // TODO create integration test from this
 object TestSchema1 extends App {
-  val builder = new SchemaBuilder("io.shiftleft.codepropertygraph.generated")
+  val builder = new SchemaBuilder("Cpg", "io.shiftleft.codepropertygraph.generated")
 
   implicit val schemaInfo = SchemaInfo.forClass(getClass)
 

--- a/codegen/src/main/scala/overflowdb/schema/testschema1/TestSchema1.scala
+++ b/codegen/src/main/scala/overflowdb/schema/testschema1/TestSchema1.scala
@@ -48,7 +48,7 @@ object TestSchema1 extends App {
   val edgekey1Lst = builder
     .addProperty("EDGEKEY_1_LST", ValueType.Int,
       comment = "test list edge key"
-    ).asIndexedList()
+    ).asList()
     .protoId(6999)
 
   // edge types

--- a/codegen/src/main/scala/overflowdb/schema/testschema2/TestSchema2.scala
+++ b/codegen/src/main/scala/overflowdb/schema/testschema2/TestSchema2.scala
@@ -8,7 +8,7 @@ import overflowdb.storage.ValueTypes
 
 // TODO create integration test from this
 object TestSchema2 extends App {
-  val builder = new SchemaBuilder("io.shiftleft.codepropertygraph.generated")
+  val builder = new SchemaBuilder("Cpg", "io.shiftleft.codepropertygraph.generated")
   val base = Base(builder)
   val javaSpecific = JavaSpecific(builder, base)
   new CodeGen(builder.build).run(new File("target"))

--- a/codegen/src/main/scala/overflowdb/schema/testschema3/TestSchema3.scala
+++ b/codegen/src/main/scala/overflowdb/schema/testschema3/TestSchema3.scala
@@ -7,7 +7,7 @@ import java.io.File
 
 // TODO create integration test from this
 object TestSchema3 extends App {
-  val builder = new SchemaBuilder("io.shiftleft.codepropertygraph.generated")
+  val builder = new SchemaBuilder("Cpg","io.shiftleft.codepropertygraph.generated")
 
   // node types
   val outer = builder.addNodeType("OUTER", "outer node")

--- a/codegen/src/main/scala/overflowdb/schema/testschema3/TestSchema3.scala
+++ b/codegen/src/main/scala/overflowdb/schema/testschema3/TestSchema3.scala
@@ -12,7 +12,7 @@ object TestSchema3 extends App {
   // node types
   val outer = builder.addNodeType("OUTER", "outer node")
   val inner = builder.addNodeType("INNER", "contained inner node")
-  outer.addContainedNode(inner, "innerFoo", Property.Cardinality.ISeq)
+  outer.addContainedNode(inner, "innerFoo", Property.Cardinality.List)
 
   new CodeGen(builder.build).run(new File("target"))
 }

--- a/codegen/src/main/scala/overflowdb/schema/testschema4/TestSchema4.scala
+++ b/codegen/src/main/scala/overflowdb/schema/testschema4/TestSchema4.scala
@@ -7,7 +7,7 @@ import java.io.File
 
 // TODO create integration test from this
 object TestSchema4 extends App {
-  val builder = new SchemaBuilder("io.shiftleft.codepropertygraph.generated")
+  val builder = new SchemaBuilder("Cpg","io.shiftleft.codepropertygraph.generated")
 
   implicit val schemaInfo = SchemaInfo.forClass(getClass)
 

--- a/codegen/src/test/scala/overflowdb/schema/SchemaBuilderTest.scala
+++ b/codegen/src/test/scala/overflowdb/schema/SchemaBuilderTest.scala
@@ -28,7 +28,7 @@ class SchemaBuilderTest extends AnyWordSpec {
       (case1, modification1) <- schemaModifications
       (case2, modification2) <- schemaModifications
     } {
-      val builder = new SchemaBuilder("test")
+      val builder = new SchemaBuilder("test", "testpkg")
       modification1(builder)
       modification2(builder)
 

--- a/integration-tests/schemas/src/main/scala/TestSchema.scala
+++ b/integration-tests/schemas/src/main/scala/TestSchema.scala
@@ -1,7 +1,7 @@
 import overflowdb.schema.SchemaBuilder
 
 trait TestSchema {
-  val builder = new SchemaBuilder(basePackage = getClass.getCanonicalName.toLowerCase)
+  val builder = new SchemaBuilder(domainShortName = "TestSchema", basePackage = getClass.getCanonicalName.toLowerCase)
   lazy val instance = builder.build
 }
 

--- a/integration-tests/schemas/src/main/scala/TestSchema01.scala
+++ b/integration-tests/schemas/src/main/scala/TestSchema01.scala
@@ -8,7 +8,7 @@ class TestSchema01 extends TestSchema {
   val order = builder.addProperty("ORDER", ValueType.Int, "General ordering property.")
 
   val options = builder.addProperty("OPTIONS", ValueType.String, "Options of a node").asList()
-  val placements = builder.addProperty("PLACEMENTS", ValueType.Int, "placements in some league").asIndexedList()
+  val placements = builder.addProperty("PLACEMENTS", ValueType.Int, "placements in some league").asList()
 
   val node1 = builder.addNodeType(
     name = "NODE1",

--- a/integration-tests/schemas/src/main/scala/TestSchema04.scala
+++ b/integration-tests/schemas/src/main/scala/TestSchema04.scala
@@ -15,16 +15,15 @@ class TestSchema04 extends TestSchema {
   val double2 = builder.addProperty("DOUBLE2", ValueType.Double).mandatory(default = Double.NaN)
   val char = builder.addProperty("CHAR", ValueType.Char).mandatory(default = '?')
   val intList  = builder.addProperty("INT_LIST", ValueType.Int).asList()
-  val intIndexedList  = builder.addProperty("INT_LIST_INDEXED", ValueType.Int).asIndexedList()
 
   val node1 = builder.addNodeType("NODE1")
-    .addProperties(bool, string, byte, short, int, long, float1, float2, double1, double2, char, intList, intIndexedList)
+    .addProperties(bool, string, byte, short, int, long, float1, float2, double1, double2, char, intList)
 
   // TODO use same `mandatory` and not-null api as for regular properties. for now, staying with nullable contained nodes as before
   node1.addContainedNode(node1, "node1Inner", Cardinality.One(Default(null)))
 
   val edge1 = builder.addEdgeType("EDGE1")
-    .addProperties(bool, string, byte, short, int, long, float1, float2, double1, double2, char, intList, intIndexedList)
+    .addProperties(bool, string, byte, short, int, long, float1, float2, double1, double2, char, intList)
 
   node1.addOutEdge(edge1, node1)
 }

--- a/integration-tests/tests/src/test/scala/Schema01Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema01Test.scala
@@ -27,7 +27,7 @@ class Schema01Test extends AnyWordSpec with Matchers {
   }
 
   "working with a concrete sample graph" can {
-    val graph = Graph.open(Config.withDefaults, nodes.Factories.allAsJava, edges.Factories.allAsJava)
+    val graph = TestSchema.empty.graph
 
     val node1a = graph.addNode(Node1.Label, Node1.PropertyNames.Name, "node 1a", PropertyNames.ORDER, 2)
     val node1b = graph.addNode(Node1.Label, Node1.PropertyNames.Name, "node 1b")

--- a/integration-tests/tests/src/test/scala/Schema02Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema02Test.scala
@@ -22,7 +22,7 @@ class Schema02Test extends AnyWordSpec with Matchers {
   }
 
   "working with a concrete sample graph" can {
-    val graph = Graph.open(Config.withDefaults, nodes.Factories.allAsJava, edges.Factories.allAsJava)
+    val graph = TestSchema.empty.graph
 
     val node1 = graph.addNode(Node1.Label, Node1.PropertyNames.Name, "node 01", PropertyNames.ORDER, 4)
     val node2 = graph.addNode(Node2.Label, PropertyNames.NAME, "node 02", PropertyNames.ORDER, 3)

--- a/integration-tests/tests/src/test/scala/Schema04Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema04Test.scala
@@ -8,6 +8,7 @@ import testschema04.nodes._
 import testschema04.traversal._
 
 import java.nio.file.Files
+import scala.collection.immutable.ArraySeq
 
 class Schema04Test extends AnyWordSpec with Matchers {
 
@@ -86,7 +87,7 @@ class Schema04Test extends AnyWordSpec with Matchers {
       Properties.DOUBLE1.of(Double.NaN),
       Properties.DOUBLE2.of(105.5),
       Properties.CHAR.of('Z'),
-      Properties.INT_LIST.of(Seq(3, 4, 5)),
+      Properties.INT_LIST.of(ArraySeq(3, 4, 5)),
     )
     properties.foreach(node1.setProperty)
     properties.foreach(edge1.setProperty)

--- a/integration-tests/tests/src/test/scala/Schema04Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema04Test.scala
@@ -70,7 +70,7 @@ class Schema04Test extends AnyWordSpec with Matchers {
   "defined property values" in {
     val storageLocation = Files.createTempFile("overflowdb-codegen-tests", "odb.bin")
 
-    def openGraph(): Graph = TestSchema.withStorage(storageLocation.toString).graph
+    def openGraph(): Graph = TestSchema.withStorage(storageLocation).graph
     val graph = openGraph()
 
     val node1 = graph.addNode(Node1.Label)

--- a/integration-tests/tests/src/test/scala/Schema04Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema04Test.scala
@@ -139,9 +139,8 @@ class Schema04Test extends AnyWordSpec with Matchers {
       edge1.double1.isNaN shouldBe true
       edge1.double2 shouldBe 105.5
       edge1.char shouldBe 'Z'
-      // TODO handle later in separate PR
-      //    edge1.intList shouldBe Seq(3, 4, 5)
-      //    edge1.intListIndexed shouldBe IndexedSeq(7, 8, 9)
+      edge1.intList shouldBe Seq(3, 4, 5)
+      edge1.intListIndexed shouldBe IndexedSeq(7, 8, 9)
       edge1.propertyKeys().contains("STR") shouldBe true
       edge1.propertyDefaultValue("STR") shouldBe "<[empty]>"
       edge1.propertyDefaultValue("DOESNT_EXIST") shouldBe null

--- a/integration-tests/tests/src/test/scala/Schema04Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema04Test.scala
@@ -30,7 +30,6 @@ class Schema04Test extends AnyWordSpec with Matchers {
     node1.double2.isNaN shouldBe true
     node1.char shouldBe '?'
     node1.intList.size shouldBe 0
-    node1.intListIndexed.size shouldBe 0
     node1.propertyKeys().contains("STR") shouldBe true
     node1.propertyDefaultValue("STR") shouldBe "<[empty]>"
     node1.propertyDefaultValue("DOESNT_EXIST") shouldBe null
@@ -51,7 +50,6 @@ class Schema04Test extends AnyWordSpec with Matchers {
     edge1.double2.isNaN shouldBe true
     edge1.char shouldBe '?'
     edge1.intList.size shouldBe 0
-    edge1.intListIndexed.size shouldBe 0
     edge1.propertyKeys().contains("STR") shouldBe true
     edge1.propertyDefaultValue("STR") shouldBe "<[empty]>"
     edge1.propertyDefaultValue("DOESNT_EXIST") shouldBe null
@@ -89,7 +87,6 @@ class Schema04Test extends AnyWordSpec with Matchers {
       Properties.DOUBLE2.of(105.5),
       Properties.CHAR.of('Z'),
       Properties.INT_LIST.of(Seq(3, 4, 5)),
-      Properties.INT_LIST_INDEXED.of(IndexedSeq(7, 8, 9))
     )
     properties.foreach(node1.setProperty)
     properties.foreach(edge1.setProperty)
@@ -116,7 +113,6 @@ class Schema04Test extends AnyWordSpec with Matchers {
       node1.double2 shouldBe 105.5
       node1.char shouldBe 'Z'
       node1.intList shouldBe Seq(3, 4, 5)
-      node1.intListIndexed shouldBe IndexedSeq(7, 8, 9)
       node1.node1Inner shouldBe node2
       node1.propertyKeys().contains("STR") shouldBe true
       node1.propertyDefaultValue("STR") shouldBe "<[empty]>"
@@ -141,7 +137,6 @@ class Schema04Test extends AnyWordSpec with Matchers {
       edge1.double2 shouldBe 105.5
       edge1.char shouldBe 'Z'
       edge1.intList shouldBe Seq(3, 4, 5)
-      edge1.intListIndexed shouldBe IndexedSeq(7, 8, 9)
       edge1.propertyKeys().contains("STR") shouldBe true
       edge1.propertyDefaultValue("STR") shouldBe "<[empty]>"
       edge1.propertyDefaultValue("DOESNT_EXIST") shouldBe null
@@ -154,7 +149,6 @@ class Schema04Test extends AnyWordSpec with Matchers {
 
       node1Trav.str.head shouldBe "foo"
       node1Trav.intList.l shouldBe Seq(3, 4, 5)
-      node1Trav.intListIndexed.l shouldBe IndexedSeq(7, 8, 9)
       node1Trav.property(Node1.Properties.Str).head shouldBe "foo"
       edge1Trav.property(Edge1.Properties.Str).head shouldBe "foo"
     }

--- a/integration-tests/tests/src/test/scala/Schema04Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema04Test.scala
@@ -72,7 +72,6 @@ class Schema04Test extends AnyWordSpec with Matchers {
     def openGraph() = Graph.open(Config.withDefaults.withStorageLocation(storageLocation.toString), nodes.Factories.allAsJava, edges.Factories.allAsJava)
     val graph = openGraph()
 
-
     val node1 = graph.addNode(Node1.Label)
     val node2 = graph.addNode(Node1.Label).asInstanceOf[Node1]
     val edge1 = node1.addEdge(Edge1.Label, node2).asInstanceOf[Edge1]
@@ -88,9 +87,8 @@ class Schema04Test extends AnyWordSpec with Matchers {
       Properties.DOUBLE1.of(Double.NaN),
       Properties.DOUBLE2.of(105.5),
       Properties.CHAR.of('Z'),
-      // TODO bring back later - persistence of lists is currently broken
-//      Properties.INT_LIST.of(Seq(3, 4, 5)),
-//      Properties.INT_LIST_INDEXED.of(IndexedSeq(7, 8, 9))
+      Properties.INT_LIST.of(Seq(3, 4, 5)),
+      Properties.INT_LIST_INDEXED.of(IndexedSeq(7, 8, 9))
     )
     properties.foreach(node1.setProperty)
     properties.foreach(edge1.setProperty)
@@ -116,9 +114,8 @@ class Schema04Test extends AnyWordSpec with Matchers {
       node1.double1.isNaN shouldBe true
       node1.double2 shouldBe 105.5
       node1.char shouldBe 'Z'
-      // TODO bring back in, this doesn't currently work with persistence...
-      //      node1.intList shouldBe Seq(3, 4, 5)
-      //      node1.intListIndexed shouldBe IndexedSeq(7, 8, 9)
+      node1.intList shouldBe Seq(3, 4, 5)
+      node1.intListIndexed shouldBe IndexedSeq(7, 8, 9)
       node1.node1Inner shouldBe node2
       node1.propertyKeys().contains("STR") shouldBe true
       node1.propertyDefaultValue("STR") shouldBe "<[empty]>"
@@ -177,8 +174,8 @@ class Schema04Test extends AnyWordSpec with Matchers {
       def edge1Trav = graph.edges(Edge1.Label).cast[Edge1]
 
       node1Trav.str.head shouldBe "foo"
-//      node1Trav.intList.l shouldBe Seq(3, 4, 5)
-//      node1Trav.intListIndexed.l shouldBe IndexedSeq(7, 8, 9)
+      node1Trav.intList.l shouldBe Seq(3, 4, 5)
+      node1Trav.intListIndexed.l shouldBe IndexedSeq(7, 8, 9)
       node1Trav.property(Node1.Properties.Str).head shouldBe "foo"
       edge1Trav.property(Edge1.Properties.Str).head shouldBe "foo"
     }

--- a/integration-tests/tests/src/test/scala/Schema04Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema04Test.scala
@@ -149,27 +149,6 @@ class Schema04Test extends AnyWordSpec with Matchers {
       edge1.property("DOESNT_EXIST") shouldBe null
       edge1.propertiesMap.get("STR") shouldBe "foo"
 
-      edge1.bool shouldBe false
-      edge1.str shouldBe "foo"
-      edge1.byte shouldBe 100
-      edge1.short shouldBe 101
-      edge1.int shouldBe 102
-      edge1.long shouldBe 103
-      edge1.float1.isNaN shouldBe true
-      edge1.float2 shouldBe 104.4f
-      edge1.double1.isNaN shouldBe true
-      edge1.double2 shouldBe 105.5
-      edge1.char shouldBe 'Z'
-      // TODO handle later in separate PR
-      //    edge1.intList shouldBe Seq(3, 4, 5)
-      //    edge1.intListIndexed shouldBe IndexedSeq(7, 8, 9)
-      edge1.propertyKeys().contains("STR") shouldBe true
-      edge1.propertyDefaultValue("STR") shouldBe "<[empty]>"
-      edge1.propertyDefaultValue("DOESNT_EXIST") shouldBe null
-      edge1.property(Node1.Properties.Str) shouldBe "foo"
-      edge1.property("DOESNT_EXIST") shouldBe null
-      edge1.propertiesMap.get("STR") shouldBe "foo"
-
       def node1Trav = graph.nodes(Node1.Label).cast[Node1]
       def edge1Trav = graph.edges(Edge1.Label).cast[Edge1]
 

--- a/integration-tests/tests/src/test/scala/Schema04Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema04Test.scala
@@ -154,4 +154,18 @@ class Schema04Test extends AnyWordSpec with Matchers {
       edge1Trav.property(Edge1.Properties.Str).head shouldBe "foo"
     }
   }
+
+  "handle primitive arrays for list properties" in {
+    def openGraph(): Graph = TestSchema.empty.graph
+    val graph = openGraph()
+
+    val node1 = graph.addNode(Node1.Label).asInstanceOf[Node1]
+    val node2 = graph.addNode(Node1.Label).asInstanceOf[Node1]
+    val edge1 = node1.addEdge(Edge1.Label, node2).asInstanceOf[Edge1]
+    node1.setProperty(Properties.INT_LIST.name, Array(1,2,3))
+    edge1.setProperty(Properties.INT_LIST.name, Array(3,4,5))
+
+    node1.intList shouldBe IndexedSeq(1,2,3)
+    edge1.intList shouldBe IndexedSeq(3,4,5)
+  }
 }

--- a/integration-tests/tests/src/test/scala/Schema04Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema04Test.scala
@@ -37,7 +37,7 @@ class Schema04Test extends AnyWordSpec with Matchers {
     node1.property(Node1.Properties.Str) shouldBe "<[empty]>"
     node1.property("DOESNT_EXIST") shouldBe null
     node1.propertiesMap.get("STR") shouldBe "<[empty]>"
-    node1.get.propertiesMapWithoutDefaults.isEmpty shouldBe true
+    node1.get.propertiesMapForStorage.isEmpty shouldBe true
 
     edge1.bool shouldBe true
     edge1.str shouldBe "<[empty]>"
@@ -125,8 +125,8 @@ class Schema04Test extends AnyWordSpec with Matchers {
       node1.property("DOESNT_EXIST") shouldBe null
       node1.propertiesMap.get("STR") shouldBe "foo"
       node1.propertiesMap.get(Node1.PropertyNames.Node1inner) shouldBe node2
-      node1.get.propertiesMapWithoutDefaults.get(PropertyNames.STR) shouldBe "foo"
-      node1.get.propertiesMapWithoutDefaults.get(Node1.PropertyNames.Node1inner) shouldBe node2
+      node1.get.propertiesMapForStorage.get(PropertyNames.STR) shouldBe "foo"
+      node1.get.propertiesMapForStorage.get(Node1.PropertyNames.Node1inner) shouldBe node2
 
       edge1.bool shouldBe false
       edge1.str shouldBe "foo"

--- a/integration-tests/tests/src/test/scala/Schema04Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema04Test.scala
@@ -12,7 +12,7 @@ import java.nio.file.Files
 class Schema04Test extends AnyWordSpec with Matchers {
 
   "default property values" in {
-    val graph = Graph.open(Config.withDefaults, nodes.Factories.allAsJava, edges.Factories.allAsJava)
+    val graph = TestSchema.empty.graph
 
     val node1 = graph.addNode(Node1.Label).asInstanceOf[Node1]
     val node2 = graph.addNode(Node1.Label).asInstanceOf[Node1]
@@ -69,7 +69,8 @@ class Schema04Test extends AnyWordSpec with Matchers {
 
   "defined property values" in {
     val storageLocation = Files.createTempFile("overflowdb-codegen-tests", "odb.bin")
-    def openGraph() = Graph.open(Config.withDefaults.withStorageLocation(storageLocation.toString), nodes.Factories.allAsJava, edges.Factories.allAsJava)
+
+    def openGraph(): Graph = TestSchema.withStorage(storageLocation.toString).graph
     val graph = openGraph()
 
     val node1 = graph.addNode(Node1.Label)

--- a/integration-tests/tests/src/test/scala/Schema05Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema05Test.scala
@@ -10,7 +10,7 @@ import testschema05.traversal._
 class Schema05Test extends AnyWordSpec with Matchers {
 
   "default property values: all empty" in {
-    val graph = Graph.open(Config.withDefaults, nodes.Factories.allAsJava, edges.Factories.allAsJava)
+    val graph = TestSchema.empty.graph
 
     val node1 = graph.addNode(Node1.Label).asInstanceOf[Node1]
     val node2 = graph.addNode(Node1.Label).asInstanceOf[Node1]
@@ -43,7 +43,7 @@ class Schema05Test extends AnyWordSpec with Matchers {
   }
 
   "defined property values" in {
-    val graph = Graph.open(Config.withDefaults, nodes.Factories.allAsJava, edges.Factories.allAsJava)
+    val graph = TestSchema.empty.graph
 
     val node1 = graph.addNode(Node1.Label).asInstanceOf[Node1]
     val node2 = graph.addNode(Node1.Label).asInstanceOf[Node1]

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,5 +6,5 @@ object Projects {
 }
 
 object Versions {
-  val overflowdb = "1.51"
+  val overflowdb = "1.52"
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,5 +6,5 @@ object Projects {
 }
 
 object Versions {
-  val overflowdb = "1.49+1-7be9ab86"
+  val overflowdb = "1.50+5-91718303"
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,5 +6,5 @@ object Projects {
 }
 
 object Versions {
-  val overflowdb = "1.50+5-91718303"
+  val overflowdb = "1.50+6-90fcc2e5"
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,5 +6,5 @@ object Projects {
 }
 
 object Versions {
-  val overflowdb = "1.50+6-90fcc2e5"
+  val overflowdb = "1.51"
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,5 +6,5 @@ object Projects {
 }
 
 object Versions {
-  val overflowdb = "1.49"
+  val overflowdb = "1.49+1-7be9ab86"
 }


### PR DESCRIPTION
* use IndexedSeq (backed by ArraySeq) everywhere
* use zero-copy ArraySeq.unsafeWrapArray / ArraySeq.unsafeArray as suggested by @bbrehm
* drop Cardinality.ISeq
* handle lists for edge properties as well
* provide general conversion function (depends on https://github.com/ShiftLeftSecurity/overflowdb/pull/206)
* generate domain starting point (equivalent of `Cpg.scala`)