### PR TITLE
NewNodes: improve setters for cardinalities ZeroOrOne and List

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1577,10 +1577,13 @@ class CodeGen(schema: Schema) {
         val typ = getCompleteType(containedNode)
         fieldDescriptions += ((containedNode.localName, typ, defaultImpl))
       }
-      val defaultsVal = fieldDescriptions.reverse
-        .map {
-          case (name, typ, default) => s"var $name: $typ = $default"
-        }.mkString(", ")
+      val defaultsVal = fieldDescriptions.reverse.map {
+        case (name, typ, default) => s"var $name: $typ = $default"
+      }.mkString(", ")
+
+      val builderSetters = fieldDescriptions
+        .map {case (name, typ, _) => s"def $name(x: $typ): this.type = { result.$name = x; this }" }
+        .mkString("\n")
 
       val propertiesMapImpl = {
         val putKeysImpl = keys
@@ -1626,10 +1629,6 @@ class CodeGen(schema: Schema) {
            |$propertiesImpl
            |}""".stripMargin
       }
-
-      val builderSetters = fieldDescriptions
-        .map {case (name, typ, _) => s"def ${name}(x : $typ) : this.type = { result.$name = x; this }" }
-        .mkString("\n")
 
       val nodeClassName = nodeType.className
 

--- a/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -102,14 +102,14 @@ object Helpers {
   def getCompleteType[A](property: Property[_]): String =
     getCompleteType(property.cardinality, typeFor(property))
 
-  def getCompleteType(containedNode: ContainedNode): String = {
+  def typeFor(containedNode: ContainedNode): String = {
     val className = containedNode.nodeType.className
-    val tpe =
-      if (DefaultNodeTypes.AllClassNames.contains(className)) className
-      else className + "Base"
-
-    getCompleteType(containedNode.cardinality, tpe)
+    if (DefaultNodeTypes.AllClassNames.contains(className)) className
+    else className + "Base"
   }
+
+  def getCompleteType(containedNode: ContainedNode): String =
+    getCompleteType(containedNode.cardinality, typeFor(containedNode))
 
   def getCompleteType(cardinality: Property.Cardinality, valueType: String): String = {
     import Property.Cardinality

--- a/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -99,28 +99,24 @@ object Helpers {
     }
   }
 
-  def getCompleteType[A](property: Property[_]): String = {
-    import Property.Cardinality
-    val valueType = typeFor(property)
-    property.cardinality match {
-      case Cardinality.One(_)    => valueType
-      case Cardinality.ZeroOrOne => s"Option[$valueType]"
-      case Cardinality.List      => s"IndexedSeq[$valueType]"
-    }
-  }
+  def getCompleteType[A](property: Property[_]): String =
+    getCompleteType(property.cardinality, typeFor(property))
 
   def getCompleteType(containedNode: ContainedNode): String = {
     val className = containedNode.nodeType.className
-    val tpe = if (DefaultNodeTypes.AllClassNames.contains(className)) {
-      className
-    } else {
-      className + "Base"
-    }
+    val tpe =
+      if (DefaultNodeTypes.AllClassNames.contains(className)) className
+      else className + "Base"
 
-    containedNode.cardinality match {
-      case Property.Cardinality.ZeroOrOne => s"Option[$tpe]"
-      case Property.Cardinality.One(_)    => tpe
-      case Property.Cardinality.List      => s"IndexedSeq[$tpe]"
+    getCompleteType(containedNode.cardinality, tpe)
+  }
+
+  def getCompleteType(cardinality: Property.Cardinality, valueType: String): String = {
+    import Property.Cardinality
+    cardinality match {
+      case Cardinality.One(_)    => valueType
+      case Cardinality.ZeroOrOne => s"Option[$valueType]"
+      case Cardinality.List      => s"IndexedSeq[$valueType]"
     }
   }
 

--- a/codegen/src/main/scala/overflowdb/schema/Schema.scala
+++ b/codegen/src/main/scala/overflowdb/schema/Schema.scala
@@ -186,9 +186,7 @@ class Property[A](val name: String,
     _cardinality = Cardinality.List
     this
   }
-
 }
-
 
 object Property {
 

--- a/integration-tests/tests/src/test/scala/Schema01Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema01Test.scala
@@ -35,6 +35,7 @@ class Schema01Test extends AnyWordSpec with Matchers {
     val node2b = graph.addNode(Node2.Label, PropertyNames.NAME, "node 2b", PropertyNames.PLACEMENTS, Seq(5,1,7))
     node1a.addEdge(Edge1.Label, node2a)
     val edge2 = node2a.addEdge(Edge2.Label, node1a, PropertyNames.NAME, "edge 2", PropertyNames.ORDER, 3)
+    val node3 = graph.addNode(Node3.Label).asInstanceOf[Node3]
 
     "lookup and traverse nodes/edges/properties" in {
       // generic traversal
@@ -78,6 +79,14 @@ class Schema01Test extends AnyWordSpec with Matchers {
       node1a.setProperty(Node1.Properties.Order.of(4))
 
       // TODO generate domain-specific setters in codegen
+    }
+
+    "NewNodes" in {
+      NewNode2()
+        .name("name1")
+        .node3(node3)
+        .options(Seq("one", "two", "three"))
+        .placements(Seq(1,2,3))
     }
   }
 

--- a/integration-tests/tests/src/test/scala/Schema04Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema04Test.scala
@@ -1,7 +1,7 @@
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.traversal._
-import overflowdb.{Config, Graph}
+import overflowdb.Graph
 import testschema04._
 import testschema04.edges._
 import testschema04.nodes._


### PR DESCRIPTION
* ZeroOrOne setter: `.foo(value: Foo)` rather than `.foo(value: Option[Foo])`
* List setter: `.foo(values: IterableOnce[Foo])` rather than `.foo(values: ArraySeq[Foo])`
* add tests
* some refactorings