### PR TITLE
Re-added IDs to Node Builders

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1549,8 +1549,10 @@ class CodeGen(schema: Schema) {
          |}
          |
          |trait NewNodeBuilder[A <: NewNode] {
+         |  // TODO David/Michael: revert #98 | Begin
          |  def id: Long
          |  def id(x: Long): NewNodeBuilder[A]
+         |  // TODO David/Michael: revert #98 | End
          |  def build: A
          |}
          |
@@ -1669,14 +1671,18 @@ class CodeGen(schema: Schema) {
          |
          |class New${nodeClassName}Builder extends NewNodeBuilder[New$nodeClassName] {
          |   var result: New$nodeClassName = new New${nodeClassName}()
+         |
+         |   // TODO David/Michael: revert #98 | Begin
          |   private var _id: Long = -1L
          |   def id: Long = _id
          |   def id(x: Long): New${nodeClassName}Builder = { _id = x; this }
+         |   // TODO David/Michael: revert #98 | End
          |
          |   $builderSetters
          |
          |   def build: New${nodeClassName} = result
          |
+         |   // TODO David/Michael: revert #98 | Begin
          |   def canEqual(other: Any): Boolean = other.isInstanceOf[New${nodeClassName}Builder]
          |
          |   override def equals(other: Any): Boolean = other match {
@@ -1690,6 +1696,7 @@ class CodeGen(schema: Schema) {
          |   }
          |
          |   override def toString = s"New${nodeClassName}Builder($${_id})"
+         |   // TODO David/Michael: revert #98 | End
          |}
          |
          |object New${nodeClassName}{

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1549,6 +1549,8 @@ class CodeGen(schema: Schema) {
          |}
          |
          |trait NewNodeBuilder[A <: NewNode] {
+         |  def id: Long
+         |  def id(x: Long): NewNodeBuilder[A]
          |  def build: A
          |}
          |
@@ -1666,12 +1668,28 @@ class CodeGen(schema: Schema) {
          |}
          |
          |class New${nodeClassName}Builder extends NewNodeBuilder[New$nodeClassName] {
-         |   val result: New$nodeClassName = new New${nodeClassName}()
+         |   var result: New$nodeClassName = new New${nodeClassName}()
+         |   private var _id: Long = -1L
+         |   def id: Long = _id
+         |   def id(x: Long): New${nodeClassName}Builder = { _id = x; this }
          |
          |   $builderSetters
          |
          |   def build: New${nodeClassName} = result
          |
+         |   def canEqual(other: Any): Boolean = other.isInstanceOf[New${nodeClassName}Builder]
+         |
+         |   override def equals(other: Any): Boolean = other match {
+         |      case that: New${nodeClassName}Builder => (that canEqual this) && _id == that._id
+         |      case _ => false
+         |   }
+         |
+         |   override def hashCode(): Int = {
+         |      val state = Seq(_id)
+         |      state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+         |   }
+         |
+         |   override def toString = s"New${nodeClassName}Builder($${_id})"
          |}
          |
          |object New${nodeClassName}{


### PR DESCRIPTION
This PR reverts [this change](https://github.com/ShiftLeftSecurity/overflowdb-codegen/commit/d03cb6d53cbfa3a2d6084ffd17a404b92c6e6ef0) which removed the ability to specify IDs in `NewNodeBuilders`. Plume relies on this to map IDs between the supported databases and the temporary in-memory ODB instances used to build the CPG. 

Plume needs [this important bug fix](https://github.com/ShiftLeftSecurity/codepropertygraph/commit/c0855241336ef9e13376b851c8a060ac7c34a78c) before I can retire Plume to the more long-term [jimple2cpg](https://github.com/joernio/jimple2cpg) as we need to re-run our experiments with the fix. 

As far as I see `codepropertygraph` seems to run fine with these changes but it would be worth a double-check.