### PR TITLE
Revert "Re-added IDs to Node Builders"

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1550,10 +1550,6 @@ class CodeGen(schema: Schema) {
          |}
          |
          |trait NewNodeBuilder[A <: NewNode] {
-         |  // TODO David/Michael: revert #98 | Begin
-         |  def id: Long
-         |  def id(x: Long): NewNodeBuilder[A]
-         |  // TODO David/Michael: revert #98 | End
          |  def build: A
          |}
          |
@@ -1671,33 +1667,12 @@ class CodeGen(schema: Schema) {
          |}
          |
          |class New${nodeClassName}Builder extends NewNodeBuilder[New$nodeClassName] {
-         |   var result: New$nodeClassName = new New${nodeClassName}()
-         |
-         |   // TODO David/Michael: revert #98 | Begin
-         |   private var _id: Long = -1L
-         |   def id: Long = _id
-         |   def id(x: Long): New${nodeClassName}Builder = { _id = x; this }
-         |   // TODO David/Michael: revert #98 | End
+         |   val result: New$nodeClassName = new New${nodeClassName}()
          |
          |   $builderSetters
          |
          |   def build: New${nodeClassName} = result
          |
-         |   // TODO David/Michael: revert #98 | Begin
-         |   def canEqual(other: Any): Boolean = other.isInstanceOf[New${nodeClassName}Builder]
-         |
-         |   override def equals(other: Any): Boolean = other match {
-         |      case that: New${nodeClassName}Builder => (that canEqual this) && _id == that._id
-         |      case _ => false
-         |   }
-         |
-         |   override def hashCode(): Int = {
-         |      val state = Seq(_id)
-         |      state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
-         |   }
-         |
-         |   override def toString = s"New${nodeClassName}Builder($${_id})"
-         |   // TODO David/Michael: revert #98 | End
          |}
          |
          |object New${nodeClassName}{


### PR DESCRIPTION
Reverts ShiftLeftSecurity/overflowdb-codegen#98

That PR was only temporary for plume, which has since been replaced by jimple2cpg
re https://github.com/joernio/joern/pull/607#issuecomment-922073782