### PR TITLE
make warning more useful

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -44,7 +44,7 @@ class CodeGen(schema: Schema) {
       property <- nodeType.propertiesWithoutInheritance
       baseType <- nodeType.extendzRecursively
       if baseType.propertiesWithoutInheritance.contains(property) && !noWarnList.contains((nodeType, property))
-    } yield s"[info]: $nodeType wouldn't need to have $property added explicitly - $baseType already brings it in"
+    } yield s"[info]: $nodeType wouldn't need to have property `${property.name}` added explicitly - $baseType already brings it in"
 
     if (warnings.size > 0) println(s"${warnings.size} warnings found:")
     warnings.sorted.foreach(println)


### PR DESCRIPTION
before:
```
NodeType(COMMENT) wouldn't need to have overflowdb.schema.Property@3b39222 added ...
```

after:
```
NodeType(COMMENT) wouldn't need to have property CODE added ...
```