### PR TITLE
move `dontWarnForDuplicateProperty` to SchemaBuilder public api

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -14,12 +14,6 @@ class CodeGen(schema: Schema) {
   val nodesPackage = s"$basePackage.nodes"
   val edgesPackage = s"$basePackage.edges"
   val traversalsPackage = s"$basePackage.traversal"
-  private val noWarnList: mutable.Set[(AbstractNodeType, Property[_])] = mutable.Set.empty
-
-  def dontWarnForDuplicateProperty(nodeType: AbstractNodeType, property: Property[_]): CodeGen = {
-    noWarnList.add((nodeType, property))
-    this
-  }
 
   def run(outputDir: java.io.File): Seq[java.io.File] = {
     warnForDuplicatePropertyDefinitions()
@@ -43,8 +37,8 @@ class CodeGen(schema: Schema) {
       nodeType <- schema.allNodeTypes
       property <- nodeType.propertiesWithoutInheritance
       baseType <- nodeType.extendzRecursively
-      if baseType.propertiesWithoutInheritance.contains(property) && !noWarnList.contains((nodeType, property))
-    } yield s"[info]: $nodeType wouldn't need to have $property added explicitly - $baseType already brings it in"
+      if baseType.propertiesWithoutInheritance.contains(property) && !schema.noWarnList.contains((nodeType, property))
+    } yield s"[info]: $nodeType wouldn't need to have property `${property.name}` added explicitly - $baseType already brings it in"
 
     if (warnings.size > 0) println(s"${warnings.size} warnings found:")
     warnings.sorted.foreach(println)

--- a/codegen/src/main/scala/overflowdb/schema/Schema.scala
+++ b/codegen/src/main/scala/overflowdb/schema/Schema.scala
@@ -16,7 +16,8 @@ class Schema(val domainShortName: String,
              val nodeTypes: Seq[NodeType],
              val edgeTypes: Seq[EdgeType],
              val constantsByCategory: Map[String, Seq[Constant]],
-             val protoOptions: Option[ProtoOptions]) {
+             val protoOptions: Option[ProtoOptions],
+             val noWarnList: Set[(AbstractNodeType, Property[_])]) {
 
   /** nodeTypes and nodeBaseTypes combined */
   lazy val allNodeTypes: Seq[AbstractNodeType] =

--- a/codegen/src/main/scala/overflowdb/schema/SchemaBuilder.scala
+++ b/codegen/src/main/scala/overflowdb/schema/SchemaBuilder.scala
@@ -3,6 +3,7 @@ package overflowdb.schema
 import overflowdb.codegen.DefaultNodeTypes
 import overflowdb.codegen.Helpers._
 import overflowdb.schema.Property.ValueType
+
 import scala.collection.mutable
 
 class SchemaBuilder(domainShortName: String, basePackage: String) {
@@ -12,6 +13,7 @@ class SchemaBuilder(domainShortName: String, basePackage: String) {
   val edgeTypes = mutable.ListBuffer.empty[EdgeType]
   val constantsByCategory = mutable.Map.empty[String, Seq[Constant]]
   var protoOptions: Option[ProtoOptions] = None
+  val noWarnList: mutable.Set[(AbstractNodeType, Property[_])] = mutable.Set.empty
 
   /** root node trait for all nodes - use if you want to be explicitly unspecific
     * n.b. 1: this one allows for StoredNode and NewNode
@@ -62,6 +64,11 @@ class SchemaBuilder(domainShortName: String, basePackage: String) {
     this
   }
 
+  def dontWarnForDuplicateProperty(nodeType: AbstractNodeType, property: Property[_]): SchemaBuilder = {
+    noWarnList.add((nodeType, property))
+    this
+  }
+
   def build: Schema = {
     val schema = new Schema(
       domainShortName,
@@ -72,6 +79,7 @@ class SchemaBuilder(domainShortName: String, basePackage: String) {
       edgeTypes.sortBy(_.name.toLowerCase).toSeq,
       constantsByCategory.toMap,
       protoOptions,
+      noWarnList.toSet,
     )
     verifyProtoIdsUnique(schema)
     schema

--- a/codegen/src/main/scala/overflowdb/schema/testschema1/TestSchema1.scala
+++ b/codegen/src/main/scala/overflowdb/schema/testschema1/TestSchema1.scala
@@ -209,7 +209,9 @@ object TestSchema1 extends App {
     )
   )
 
+  builder.dontWarnForDuplicateProperty(file, order)
+  builder.dontWarnForDuplicateProperty(namespaceBlock, order)
+
   new CodeGen(builder.build)
-    .dontWarnForDuplicateProperty(file, order)
     .run(new File("target"))
 }


### PR DESCRIPTION
This was previously in CodeGen, but since the introduction of the
codegen plugin, usage sites aren't exposed to the CodeGen any longer.