### PR TITLE
use overflowdb.traversal.filter.StringPropertyFilter for string property filters

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1224,18 +1224,15 @@ class CodeGen(schema: Schema) {
              |    if(!Misc.isRegex(pattern)){
              |      traversal.filter{node => node.${nameCamelCase} == pattern}
              |    } else {
-             |    val matcher = java.util.regex.Pattern.compile(pattern).matcher("")
-             |    traversal.filter{node =>  matcher.reset(node.$nameCamelCase); matcher.matches()}
+             |      overflowdb.traversal.filter.StringPropertyFilter.regexp(traversal)(_.$nameCamelCase, pattern)
              |    }
              |  }
              |
              |  /**
              |    * Traverse to nodes where the $nameCamelCase matches at least one of the regular expressions in `values`
              |    * */
-             |  def $nameCamelCase(patterns: $baseType*): Traversal[NodeType] = {
-             |    val matchers = patterns.map{pattern => java.util.regex.Pattern.compile(pattern).matcher("")}.toArray
-             |    traversal.filter{node => matchers.exists{ matcher => matcher.reset(node.$nameCamelCase); matcher.matches()}}
-             |   }
+             |  def $nameCamelCase(patterns: $baseType*): Traversal[NodeType] =
+             |    overflowdb.traversal.filter.StringPropertyFilter.regexpMultiple(traversal)(_.$nameCamelCase, patterns)
              |
              |  /**
              |    * Traverse to nodes where $nameCamelCase matches `value` exactly.

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1255,8 +1255,7 @@ class CodeGen(schema: Schema) {
              |    if(!Misc.isRegex(pattern)){
              |      traversal.filter{node => node.${nameCamelCase} != pattern}
              |    } else {
-             |    val matcher = java.util.regex.Pattern.compile(pattern).matcher("")
-             |    traversal.filter{node =>  matcher.reset(node.$nameCamelCase); !matcher.matches()}
+             |      overflowdb.traversal.filter.StringPropertyFilter.regexpNot(traversal)(_.$nameCamelCase, pattern)
              |    }
              |  }
              |
@@ -1264,8 +1263,7 @@ class CodeGen(schema: Schema) {
              |    * Traverse to nodes where $nameCamelCase does not match any of the regular expressions in `values`.
              |    * */
              |  def ${nameCamelCase}Not(patterns: $baseType*): Traversal[NodeType] = {
-             |    val matchers = patterns.map{pattern => java.util.regex.Pattern.compile(pattern).matcher("")}.toArray
-             |    traversal.filter{node => !matchers.exists{ matcher => matcher.reset(node.$nameCamelCase); matcher.matches()}}
+             |      overflowdb.traversal.filter.StringPropertyFilter.regexpNotMultiple(traversal)(_.$nameCamelCase, patterns)
              |   }
              |
              |""".stripMargin

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1276,8 +1276,7 @@ class CodeGen(schema: Schema) {
              |    if(!Misc.isRegex(pattern)){
              |      traversal.filter{node => node.$nameCamelCase.isDefined && node.${nameCamelCase}.get == pattern}
              |    } else {
-             |    val matcher = java.util.regex.Pattern.compile(pattern).matcher("")
-             |    traversal.filter{node => node.$nameCamelCase.isDefined && {matcher.reset(node.$nameCamelCase.get); matcher.matches()}}
+             |      overflowdb.traversal.filter.StringPropertyFilter.regexp(traversal.filter(_.$nameCamelCase.isDefined))(_.$nameCamelCase.get, pattern)
              |    }
              |  }
              |
@@ -1285,9 +1284,8 @@ class CodeGen(schema: Schema) {
              |    * Traverse to nodes where the $nameCamelCase matches at least one of the regular expressions in `values`
              |    * */
              |  def $nameCamelCase(patterns: $baseType*): Traversal[NodeType] = {
-             |    val matchers = patterns.map{pattern => java.util.regex.Pattern.compile(pattern).matcher("")}.toArray
-             |    traversal.filter{node => node.$nameCamelCase.isDefined && matchers.exists{ matcher => matcher.reset(node.$nameCamelCase.get); matcher.matches()}}
-             |   }
+             |    overflowdb.traversal.filter.StringPropertyFilter.regexpMultiple(traversal.filter(_.$nameCamelCase.isDefined))(_.$nameCamelCase.get, patterns)
+             |  }
              |
              |  /**
              |    * Traverse to nodes where $nameCamelCase matches `value` exactly.
@@ -1310,8 +1308,7 @@ class CodeGen(schema: Schema) {
              |    if(!Misc.isRegex(pattern)){
              |      traversal.filter{node => node.$nameCamelCase.isEmpty || node.${nameCamelCase}.get != pattern}
              |    } else {
-             |    val matcher = java.util.regex.Pattern.compile(pattern).matcher("")
-             |    traversal.filter{node => node.$nameCamelCase.isEmpty || {matcher.reset(node.$nameCamelCase.get); !matcher.matches()}}
+             |      overflowdb.traversal.filter.StringPropertyFilter.regexpNot(traversal.filter(_.$nameCamelCase.isDefined))(_.$nameCamelCase.get, pattern)
              |    }
              |  }
              |
@@ -1319,8 +1316,7 @@ class CodeGen(schema: Schema) {
              |    * Traverse to nodes where $nameCamelCase does not match any of the regular expressions in `values`.
              |    * */
              |  def ${nameCamelCase}Not(patterns: $baseType*): Traversal[NodeType] = {
-             |    val matchers = patterns.map{pattern => java.util.regex.Pattern.compile(pattern).matcher("")}.toArray
-             |    traversal.filter{node => node.$nameCamelCase.isEmpty || !matchers.exists{ matcher => matcher.reset(node.$nameCamelCase.get); matcher.matches()}}
+             |    overflowdb.traversal.filter.StringPropertyFilter.regexpNotMultiple(traversal.filter(_.$nameCamelCase.isDefined))(_.$nameCamelCase.get, patterns)
              |   }
              |
              |""".stripMargin

--- a/integration-tests/tests/src/test/scala/Schema02Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema02Test.scala
@@ -160,6 +160,23 @@ class Schema02Test extends AnyWordSpec with Matchers {
       node1Traversal.orderLt(4).size shouldBe 0
       node1Traversal.orderLte(4).size shouldBe 1
     }
+
+  }
+
+  "generated string property filters" in {
+    val graph = TestSchema.empty.graph
+    val node1 = graph.addNode(Node1.Label, Node1.PropertyNames.Name, "node1 name")
+    val node2 = graph.addNode(Node1.Label, Node1.PropertyNames.Name,
+      """node2 name line 1
+        |node2 name line 2""")
+    def node1Traversal = graph.nodes(Node1.Label).cast[Node1]
+
+    node1Traversal.size shouldBe 2
+    node1Traversal.name(".*").size shouldBe 2
+    node1Traversal.name(".*name.*").size shouldBe 2
+    node1Traversal.name(".*line 2.*").size shouldBe 1
+    node1Traversal.name(".*node1.*").size shouldBe 1
+    node1Traversal.name("nomatch", ".*node1.*").size shouldBe 1
   }
 
   "marker traits" in {

--- a/integration-tests/tests/src/test/scala/Schema02Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema02Test.scala
@@ -163,22 +163,6 @@ class Schema02Test extends AnyWordSpec with Matchers {
 
   }
 
-  "generated string property filters" in {
-    val graph = TestSchema.empty.graph
-    val node1 = graph.addNode(Node1.Label, Node1.PropertyNames.Name, "node1 name")
-    val node2 = graph.addNode(Node1.Label, Node1.PropertyNames.Name,
-      """node2 name line 1
-        |node2 name line 2""")
-    def node1Traversal = graph.nodes(Node1.Label).cast[Node1]
-
-    node1Traversal.size shouldBe 2
-    node1Traversal.name(".*").size shouldBe 2
-    node1Traversal.name(".*name.*").size shouldBe 2
-    node1Traversal.name(".*line 2.*").size shouldBe 1
-    node1Traversal.name(".*node1.*").size shouldBe 1
-    node1Traversal.name("nomatch", ".*node1.*").size shouldBe 1
-  }
-
   "marker traits" in {
     classOf[MarkerTrait1].isAssignableFrom(classOf[BaseNode]) shouldBe true
     classOf[MarkerTrait1].isAssignableFrom(classOf[Node1]) shouldBe true

--- a/integration-tests/tests/src/test/scala/Schema04Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema04Test.scala
@@ -185,4 +185,22 @@ class Schema04Test extends AnyWordSpec with Matchers {
     val node2Copy = node2.copy
     node2Copy.node1Inner shouldBe node1
   }
+
+  "generated string property filters" in {
+    val graph = TestSchema.empty.graph
+    val node1 = graph.addNode(Node1.Label, Node1.PropertyNames.Str, "node1 name")
+    val node2 = graph.addNode(Node1.Label, Node1.PropertyNames.Str,
+      """node2 name line 1
+        |node2 name line 2""")
+    val node3 = graph.addNode(Node1.Label)
+    def node1Traversal = graph.nodes(Node1.Label).cast[Node1]
+
+    node1Traversal.size shouldBe 3
+    node1Traversal.str(".*").size shouldBe 3
+    node1Traversal.str(".*name.*").size shouldBe 2
+    node1Traversal.str(".*node1.*").size shouldBe 1
+    node1Traversal.str(".*line 2.*").size shouldBe 1
+    node1Traversal.str("nomatch", ".*node1.*").size shouldBe 1
+  }
+
 }

--- a/integration-tests/tests/src/test/scala/Schema04Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema04Test.scala
@@ -199,8 +199,13 @@ class Schema04Test extends AnyWordSpec with Matchers {
     node1Traversal.str(".*").size shouldBe 3
     node1Traversal.str(".*name.*").size shouldBe 2
     node1Traversal.str(".*node1.*").size shouldBe 1
-    node1Traversal.str(".*line 2.*").size shouldBe 1
-    node1Traversal.str("nomatch", ".*node1.*").size shouldBe 1
+    node1Traversal.str(".*line 2.*").size shouldBe 1 // testing multi line matcher
+    node1Traversal.str("nomatch", ".*line 2.*").size shouldBe 1
+    node1Traversal.strExact("node1 name").size shouldBe 1
+    node1Traversal.strExact("nomatch", "node1 name").size shouldBe 1
+    node1Traversal.strNot(".*node1.*").size shouldBe 2
+    node1Traversal.strNot(".*line 2.*").size shouldBe 2 // testing multi line matcher
+    node1Traversal.strNot("nomatch", ".*line 2.*").size shouldBe 2
   }
 
 }

--- a/integration-tests/tests/src/test/scala/Schema05Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema05Test.scala
@@ -96,4 +96,26 @@ class Schema05Test extends AnyWordSpec with Matchers {
     node1Trav.property(Node1.Properties.Str).head shouldBe "foo"
     edge1Trav.property(Edge1.Properties.Str).head shouldBe "foo"
   }
+
+  "generated string property filters" in {
+    val graph = TestSchema.empty.graph
+    val node1 = graph.addNode(Node1.Label, Node1.PropertyNames.Str, "node1 name")
+    val node2 = graph.addNode(Node1.Label, Node1.PropertyNames.Str,
+      """node2 name line 1
+        |node2 name line 2""")
+    val node3 = graph.addNode(Node1.Label)
+    def node1Traversal = graph.nodes(Node1.Label).cast[Node1]
+
+    node1Traversal.size shouldBe 3
+    node1Traversal.str(".*").size shouldBe 2
+    node1Traversal.str(".*name.*").size shouldBe 2
+    node1Traversal.str(".*node1.*").size shouldBe 1
+    node1Traversal.str(".*line 2.*").size shouldBe 1 // testing multi line matcher
+    node1Traversal.str("nomatch", ".*line 2.*").size shouldBe 1
+    node1Traversal.strExact("node1 name").size shouldBe 1
+    node1Traversal.strExact("nomatch", "node1 name").size shouldBe 1
+    node1Traversal.strNot(".*node1.*").size shouldBe 1
+    node1Traversal.strNot(".*line 2.*").size shouldBe 1 // testing multi line matcher
+    node1Traversal.strNot("nomatch", ".*line 2.*").size shouldBe 1
+  }
 }


### PR DESCRIPTION
* in order to get the same behaviour everywhere, e.g. multi line matching
* add tests for all string accessors for both mandatory and optional string properties