### PR TITLE
provide better error messages for schema violations

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,7 +2,7 @@ import sbt._
 import com.lucidchart.sbtcross.BaseProject
 
 object Versions {
-  val overflowdb = "1.111"
+  val overflowdb = "1.115"
   val scala_2_12 = "2.12.15"
   val scala_2_13 = "2.13.8"
   val scala_3 = "3.1.1"


### PR DESCRIPTION
Prior to this PR, if we tried to traverse an edge that was mandatory by
schema, but not actually present, we'd run into a
```
java.util.NoSuchElementException: next on empty iterator
```
... which happens a lot, unfortunately.

This PR adds some useful information - example exception:
```
overflowdb.SchemaViolationException: OUT edge with label EDGE2 to an adjacent BASE_NODE is mandatory, but not defined for this NODE2 node with id=1
```