### PR TITLE
invoke scalafmt on generated scala sources

### DIFF
--- a/codegen/build.sbt
+++ b/codegen/build.sbt
@@ -4,7 +4,8 @@ name := "overflowdb-codegen"
 
 libraryDependencies ++= Seq(
   "io.shiftleft" % "overflowdb-core" % Versions.overflowdb,
-  ("com.github.pathikrit" %% "better-files" % "3.9.1").cross(CrossVersion.for3Use2_13),
   "com.github.scopt" %% "scopt" % "4.0.1",
+  ("com.github.pathikrit" %% "better-files" % "3.9.1").cross(CrossVersion.for3Use2_13),
+  ("org.scalameta" %% "scalafmt-dynamic" % "3.4.3").cross(CrossVersion.for3Use2_13),
   "org.scalatest" %% "scalatest" % "3.2.10" % Test,
 )

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -43,7 +43,9 @@ class CodeGen(schema: Schema) {
     println(s"generated ${results.size} files in ${_outputDir}")
 
     val resultsAsJava = results.map(_.toJava)
-    if (enableScalafmt) Formatter.apply(resultsAsJava)
+    if (enableScalafmt) {
+      Formatter.run(resultsAsJava, scalafmtConfig)
+    }
     resultsAsJava
   }
 

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -28,7 +28,9 @@ class CodeGen(schema: Schema) {
       writeNewNodeFile(_outputDir)
     println(s"generated ${results.size} files in ${_outputDir}")
 
-    results.map(_.toJava)
+    val resultsAsJava = results.map(_.toJava)
+    Formatter.apply(resultsAsJava)
+    resultsAsJava
   }
 
   /* to provide feedback for potential schema optimisation: no need to redefine properties if they are already

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -154,19 +154,19 @@ class CodeGen(schema: Schema) {
     def writeConstantsFile(className: String, constants: Seq[ConstantContext]): Unit = {
       val constantsSource = constants.map { constant =>
         val documentation = constant.documentation.filter(_.nonEmpty).map(comment => s"""/** $comment */""").getOrElse("")
-        s""" $documentation
-           | ${constant.source}
+        s"""$documentation
+           |${constant.source}
            |""".stripMargin
-      }.mkString("\n")
+      }.mkString(lineSeparator)
       val allConstantsSetType = if (constantsSource.contains("PropertyKey")) "PropertyKey<?>" else "String"
       val allConstantsBody = constants.map { constant =>
-        s"     add(${constant.name});"
-      }.mkString("\n").stripSuffix("\n")
+        s"add(${constant.name});"
+      }.mkString(lineSeparator)
       val allConstantsSet =
         s"""
-           | public static Set<$allConstantsSetType> ALL = new HashSet<$allConstantsSetType>() {{
+           |public static Set<$allConstantsSetType> ALL = new HashSet<$allConstantsSetType>() {{
            |$allConstantsBody
-           | }};
+           |}};
            |""".stripMargin
       val file = baseDir.createChild(s"$className.java").write(
         s"""package $basePackage;
@@ -250,11 +250,11 @@ class CodeGen(schema: Schema) {
 
       val propertyNameDefs = properties.map { p =>
         s"""val ${p.className} = "${p.name}" """
-      }.mkString("\n|    ")
+      }.mkString(lineSeparator)
 
       val propertyDefinitions = properties.map { p =>
         propertyKeyDef(p.name, typeFor(p), p.cardinality)
-      }.mkString("\n|    ")
+      }.mkString(lineSeparator)
 
       val companionObject =
         s"""object $edgeClassName {
@@ -309,7 +309,7 @@ class CodeGen(schema: Schema) {
                  |  }
                  |}""".stripMargin
           }
-        }.mkString("\n\n  ")
+        }.mkString(lineSeparator)
       }
 
       val propertyDefaultValues = propertyDefaultValueImpl(s"$edgeClassName.PropertyDefaults", properties)
@@ -374,7 +374,7 @@ class CodeGen(schema: Schema) {
              |}
              |""".stripMargin
 
-        }.mkString("\n") + "\n"
+        }.mkString(lineSeparator)
 
       val factories = {
         val nodeFactories =
@@ -423,7 +423,7 @@ class CodeGen(schema: Schema) {
          |  /*Sets fields from newNode*/
          |  def fromNewNode(newNode: NewNode, mapping: NewNode => StoredNode):Unit = ???
          |
-         |  ${genericNeighborAccessors.mkString("\n  ")}
+         |  ${genericNeighborAccessors.mkString(lineSeparator)}
          |}
          |
          |  $keyBasedTraits
@@ -519,23 +519,23 @@ class CodeGen(schema: Schema) {
                  |  $accessorImpl1
                  |  """.stripMargin
             }
-          }.distinct.mkString("\n\n")
+          }.distinct.mkString(lineSeparator)
 
           s"""$genericEdgeAccessor
              |
              |$specificNodeAccessors""".stripMargin
-        }.mkString("\n")
+        }.mkString(lineSeparator)
       }
 
       val companionObject = {
         val propertyNames = nodeBaseType.properties.map(_.name)
         val propertyNameDefs = propertyNames.map { name =>
           s"""val ${camelCaseCaps(name)} = "$name" """
-        }.mkString("\n|    ")
+        }.mkString(lineSeparator)
 
         val propertyDefinitions = properties.map { p =>
           propertyKeyDef(p.name, typeFor(p), p.cardinality)
-        }.mkString("\n|    ")
+        }.mkString(lineSeparator)
 
         val Seq(outEdgeNames, inEdgeNames) =
           Seq(nodeBaseType.outEdges, nodeBaseType.inEdges).map { edges =>
@@ -590,15 +590,15 @@ class CodeGen(schema: Schema) {
       val propertyNames = (properties.map(_.name) ++ nodeType.containedNodes.map(_.localName)).distinct
       val propertyNameDefs = propertyNames.map { name =>
         s"""val ${camelCaseCaps(name)} = "$name" """
-      }.mkString("\n|    ")
+      }.mkString(lineSeparator)
 
       val propertyDefs = properties.map { p =>
         propertyKeyDef(p.name, typeFor(p), p.cardinality)
-      }.mkString("\n|    ")
+      }.mkString(lineSeparator)
 
       val propertyDefsForContainedNodes = nodeType.containedNodes.map { containedNode =>
         propertyKeyDef(containedNode.localName, containedNode.nodeType.className, containedNode.cardinality)
-      }.mkString("\n|    ")
+      }.mkString(lineSeparator)
 
       val (neighborOutInfos, neighborInInfos) = {
         /** the offsetPos determines the index into the adjacent nodes array of a given node type
@@ -649,7 +649,7 @@ class CodeGen(schema: Schema) {
         neighborInfos.sortBy(_.offsetPosition).map { neighborInfo =>
           val edgeClass = neighborInfo.edge.className
           s"$edgesPackage.$edgeClass.layoutInformation"
-        }.mkString(",\n")
+        }.mkString(s",$lineSeparator")
       }
       val List(outEdgeLayouts, inEdgeLayouts) = List(neighborOutInfos, neighborInInfos).map(toLayoutInformationEntry)
 
@@ -723,29 +723,29 @@ class CodeGen(schema: Schema) {
           val memberName = camelCase(key.name)
           key.cardinality match {
             case Cardinality.One(_) =>
-              s"""  properties.put("${key.name}", $memberName)"""
+              s"""properties.put("${key.name}", $memberName)"""
             case Cardinality.ZeroOrOne =>
-              s"""  $memberName.map { value => properties.put("${key.name}", value) }"""
+              s"""$memberName.map { value => properties.put("${key.name}", value) }"""
             case Cardinality.List =>
-              s"""  if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("${key.name}", $memberName) }"""
+              s"""if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("${key.name}", $memberName) }"""
           }
-        }.mkString("\n")
+        }.mkString(lineSeparator)
 
         val putContainedNodesImpl = {
           nodeType.containedNodes.map { cnt =>
             val memberName = cnt.localName
             cnt.cardinality match {
               case Cardinality.One(_) =>
-                s"""  properties.put("$memberName", this._$memberName)"""
+                s"""properties.put("$memberName", this._$memberName)"""
               case Cardinality.ZeroOrOne =>
-                s"""   $memberName.map { value => properties.put("$memberName", value) }"""
+                s"""$memberName.map { value => properties.put("$memberName", value) }"""
               case Cardinality.List =>
-                s"""  if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("$memberName", this.$memberName) }"""
+                s"""if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("$memberName", this.$memberName) }"""
             }
           }
-        }.mkString("\n")
+        }.mkString(lineSeparator)
 
-        s""" {
+        s"""{
            |  val properties = new java.util.HashMap[String, Any]
            |  $putKeysImpl
            |  $putContainedNodesImpl
@@ -760,13 +760,13 @@ class CodeGen(schema: Schema) {
           key.cardinality match {
             case Cardinality.One(default) =>
               val isDefaultValueImpl = defaultValueCheckImpl(memberName, default)
-              s"""  if (!($isDefaultValueImpl)) { properties.put("${key.name}", $memberName) }"""
+              s"""if (!($isDefaultValueImpl)) { properties.put("${key.name}", $memberName) }"""
             case Cardinality.ZeroOrOne =>
-              s"""  $memberName.map { value => properties.put("${key.name}", value) }"""
+              s"""$memberName.map { value => properties.put("${key.name}", value) }"""
             case Cardinality.List =>
-              s"""  if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("${key.name}", $memberName) }"""
+              s"""if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("${key.name}", $memberName) }"""
           }
-        }.mkString("\n")
+        }.mkString(lineSeparator)
 
         val putContainedNodesImpl = {
           nodeType.containedNodes.map { cnt =>
@@ -774,17 +774,17 @@ class CodeGen(schema: Schema) {
             cnt.cardinality match {
               case Cardinality.One(default) =>
                 val isDefaultValueImpl = defaultValueCheckImpl(s"this._$memberName", default)
-                s"""   if (!($isDefaultValueImpl)) { properties.put("$memberName", this._$memberName) }"""
+                s"""if (!($isDefaultValueImpl)) { properties.put("$memberName", this._$memberName) }"""
               case Cardinality.ZeroOrOne =>
-                s"""   $memberName.map { value => properties.put("$memberName", value) }"""
+                s"""$memberName.map { value => properties.put("$memberName", value) }"""
               case Cardinality.List =>
-                s"""  if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("$memberName", this.$memberName) }"""
+                s"""if (this._$memberName != null && this._$memberName.nonEmpty) { properties.put("$memberName", this.$memberName) }"""
             }
           }
-        }.mkString("\n")
+        }.mkString(lineSeparator)
 
 
-        s""" {
+        s"""{
            |  val properties = new java.util.HashMap[String, Any]
            |  $putKeysImpl
            |  $putContainedNodesImpl
@@ -808,7 +808,7 @@ class CodeGen(schema: Schema) {
                 s"""this._$memberName = if ($newNodeCasted.$memberName != null) $newNodeCasted.$memberName else collection.immutable.ArraySeq.empty""".stripMargin
             }
           }
-          lines.mkString("\n  ")
+          lines.mkString(lineSeparator)
         }
 
         val initRefsImpl = {
@@ -824,14 +824,14 @@ class CodeGen(schema: Schema) {
                    |  case newNode: NewNode => mapping(newNode).asInstanceOf[$containedNodeType]
                    |  case oldNode: StoredNode => oldNode.asInstanceOf[$containedNodeType]
                    |  case _ => throw new MatchError("unreachable")
-                   |}""".stripMargin.replaceAll("\n", "\n  ")
+                   |}""".stripMargin
               case Cardinality.ZeroOrOne =>
                 s"""this._$memberName = $newNodeCasted.$memberName match {
                    |  case null | None => null
                    |  case Some(newNode:NewNode) => mapping(newNode).asInstanceOf[$containedNodeType]
                    |  case Some(oldNode:StoredNode) => oldNode.asInstanceOf[$containedNodeType]
                    |  case _ => throw new MatchError("unreachable")
-                   |}""".stripMargin.replaceAll("\n", "\n  ")
+                   |}""".stripMargin
               case Cardinality.List =>
                 s"""this._$memberName =
                    |  if ($newNodeCasted.$memberName == null || $newNodeCasted.$memberName.isEmpty) {
@@ -846,10 +846,10 @@ class CodeGen(schema: Schema) {
                    |      }.toArray
                    |    )
                    |  }
-                   |""".stripMargin.replaceAll("\n", "\n  ")
+                   |""".stripMargin
             }
           }
-        }.mkString("\n\n  ")
+        }.mkString(lineSeparator)
 
         val registerFullName = if(!properties.map{_.name}.contains("FULL_NAME")) "" else {
           s"""graph.indexManager.putIfIndexed("FULL_NAME", $newNodeCasted.fullName, this.ref)"""
@@ -885,7 +885,7 @@ class CodeGen(schema: Schema) {
                    |""".stripMargin
             }
           }
-          .mkString("\n").replaceAll("\n", "\n  ")
+          .mkString(lineSeparator)
 
       val productElements: Seq[ProductElement] = {
         var currIndex = -1
@@ -907,16 +907,16 @@ class CodeGen(schema: Schema) {
       val productElementLabels =
         productElements.map { case ProductElement(name, _, index) =>
           s"""case $index => "$name" """
-        }.mkString("\n")
+        }.mkString(lineSeparator)
 
       val productElementAccessors =
         productElements.map { case ProductElement(_, accessorSrc, index) =>
           s"case $index => $accessorSrc"
-        }.mkString("\n")
+        }.mkString(lineSeparator)
 
       val abstractContainedNodeAccessors = nodeType.containedNodes.map { containedNode =>
         s"""def ${containedNode.localName}: ${getCompleteType(containedNode)}"""
-      }.mkString("\n  ")
+      }.mkString(lineSeparator)
 
       val delegatingContainedNodeAccessors = nodeType.containedNodes.map { containedNode =>
         import Property.Cardinality
@@ -931,9 +931,9 @@ class CodeGen(schema: Schema) {
         }
 
         s"""${docAnnotationMaybe(containedNode.comment)}
-           |    $src
+           |$src
            |""".stripMargin
-      }.mkString("\n  ")
+      }.mkString(lineSeparator)
 
       val nodeBaseImpl =
         s"""trait ${className}Base extends AbstractNode $mixinsForExtendedNodesBase $mixinsForMarkerTraits $propertyBasedTraits {
@@ -952,20 +952,20 @@ class CodeGen(schema: Schema) {
                |  * Traverse to ${neighborNodeInfo.neighborNode.name} via ${neighborNodeInfo.edge.name} $direction edge.
                |  */  ${docAnnotationMaybe(neighborNodeInfo.customStepDoc)}
                |def $accessorNameForNode: ${neighborNodeInfo.returnType} = get().$accessorNameForNode""".stripMargin
-        }.mkString("\n")
+        }.mkString(lineSeparator)
 
         s"""def $edgeAccessorName: overflowdb.traversal.Traversal[${neighborInfo.deriveNeighborNodeType}] = get().$edgeAccessorName
            |override def _$edgeAccessorName = get()._$edgeAccessorName
            |
            |$nodeDelegators
            |""".stripMargin
-      }.mkString("\n").replaceAll("\n", "\n    ")
+      }.mkString(lineSeparator)
 
       val nodeRefImpl = {
         val propertyDelegators = properties.map { key =>
           val name = camelCase(key.name)
-          s"""  override def $name: ${getCompleteType(key)} = get().$name"""
-        }.mkString("\n  ")
+          s"""override def $name: ${getCompleteType(key)} = get().$name"""
+        }.mkString(lineSeparator)
 
         val propertyDefaultValues = propertyDefaultValueImpl(s"$className.PropertyDefaults", properties)
 
@@ -1018,13 +1018,13 @@ class CodeGen(schema: Schema) {
               case _ => accessorImpl0
             }
             s"def ${accessorName(neighborNodeInfo)}: ${neighborNodeInfo.returnType} = $accessorImpl1"
-        }.mkString("\n")
+        }.mkString(lineSeparator)
 
         s"""def $edgeAccessorName: overflowdb.traversal.Traversal[$neighborType] = overflowdb.traversal.Traversal(createAdjacentNodeIteratorByOffSet[$neighborType]($offsetPosition))
            |override def _$edgeAccessorName = createAdjacentNodeIteratorByOffSet[StoredNode]($offsetPosition)
            |$nodeAccessors
            |""".stripMargin
-      }.mkString("\n").replaceAll("\n", "\n  ")
+      }.mkString(lineSeparator)
 
       val updateSpecificPropertyImpl: String = {
         import Property.Cardinality
@@ -1034,57 +1034,57 @@ class CodeGen(schema: Schema) {
               s"value.asInstanceOf[$baseType]"
             case Cardinality.List =>
               s"""value match {
-                 |        case null => collection.immutable.ArraySeq.empty
-                 |        case singleValue: $baseType => collection.immutable.ArraySeq(singleValue)
-                 |        case coll: IterableOnce[Any] if coll.iterator.isEmpty => collection.immutable.ArraySeq.empty
-                 |        case arr: Array[_] if arr.isEmpty => collection.immutable.ArraySeq.empty
-                 |        case arr: Array[_] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[$baseType]]
-                 |        case jCollection: java.lang.Iterable[_]  =>
-                 |          if (jCollection.iterator.hasNext) {
-                 |            collection.immutable.ArraySeq.unsafeWrapArray(
-                 |              jCollection.asInstanceOf[java.util.Collection[$baseType]].iterator.asScala.toArray)
-                 |          } else collection.immutable.ArraySeq.empty
-                 |        case iter: Iterable[_] =>
-                 |          if(iter.nonEmpty) {
-                 |            collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[$baseType]].toArray)
-                 |          } else collection.immutable.ArraySeq.empty
-                 |      }""".stripMargin
+                 |  case null => collection.immutable.ArraySeq.empty
+                 |  case singleValue: $baseType => collection.immutable.ArraySeq(singleValue)
+                 |  case coll: IterableOnce[Any] if coll.iterator.isEmpty => collection.immutable.ArraySeq.empty
+                 |  case arr: Array[_] if arr.isEmpty => collection.immutable.ArraySeq.empty
+                 |  case arr: Array[_] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[$baseType]]
+                 |  case jCollection: java.lang.Iterable[_]  =>
+                 |    if (jCollection.iterator.hasNext) {
+                 |      collection.immutable.ArraySeq.unsafeWrapArray(
+                 |        jCollection.asInstanceOf[java.util.Collection[$baseType]].iterator.asScala.toArray)
+                 |    } else collection.immutable.ArraySeq.empty
+                 |  case iter: Iterable[_] =>
+                 |    if(iter.nonEmpty) {
+                 |      collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[$baseType]].toArray)
+                 |    } else collection.immutable.ArraySeq.empty
+                 |}""".stripMargin
           }
-          s"""|      case "$name" => this._$accessorName = $setter"""
+          s"""|case "$name" => this._$accessorName = $setter"""
         }
 
-        val forKeys = properties.map(p => caseEntry(p.name, camelCase(p.name), p.cardinality, typeFor(p))).mkString("\n")
+        val forKeys = properties.map(p => caseEntry(p.name, camelCase(p.name), p.cardinality, typeFor(p))).mkString(lineSeparator)
 
         val forContainedNodes = nodeType.containedNodes.map(containedNode =>
           caseEntry(containedNode.localName, containedNode.localName, containedNode.cardinality, containedNode.nodeType.className)
-        ).mkString("\n")
+        ).mkString(lineSeparator)
 
-        s"""  override protected def updateSpecificProperty(key:String, value: Object): Unit = {
-           |    key match {
-           |    $forKeys
-           |    $forContainedNodes
-           |      case _ => PropertyErrorRegister.logPropertyErrorIfFirst(getClass, key)
-           |    }
-           |  }""".stripMargin
+        s"""override protected def updateSpecificProperty(key:String, value: Object): Unit = {
+           |  key match {
+           |  $forKeys
+           |  $forContainedNodes
+           |    case _ => PropertyErrorRegister.logPropertyErrorIfFirst(getClass, key)
+           |  }
+           |}""".stripMargin
       }
 
       val propertyImpl: String = {
         val forKeys = properties.map(key =>
           s"""|      case "${key.name}" => this._${camelCase(key.name)}"""
-        ).mkString("\n")
+        ).mkString(lineSeparator)
 
         val forContainedKeys = nodeType.containedNodes.map{containedNode =>
           val name = containedNode.localName
           s"""|      case "$name" => this._$name"""
-        }.mkString("\n")
+        }.mkString(lineSeparator)
 
         s"""override def property(key:String): Any = {
-           |    key match {
-           |      $forKeys
-           |      $forContainedKeys
-           |      case _ => null
-           |    }
-           |  }""".stripMargin
+           |  key match {
+           |    $forKeys
+           |    $forContainedKeys
+           |    case _ => null
+           |  }
+           |}""".stripMargin
       }
 
       def propertyBasedFields(properties: Seq[Property[_]]): String = {
@@ -1104,7 +1104,7 @@ class CodeGen(schema: Schema) {
 
           s"""private var $fieldName: $tpeForField = $defaultValue
              |def $publicName: $publicType = $fieldAccessor""".stripMargin
-        }.mkString("\n\n").replaceAll("\n", "\n  ")
+        }.mkString(lineSeparator)
       }
 
       val classImpl =
@@ -1195,10 +1195,10 @@ class CodeGen(schema: Schema) {
       }
 
       val implicitsForNodeTraversals =
-        schema.nodeTypes.map(_.className).sorted.map(implicitForNodeType).mkString("\n  ")
+        schema.nodeTypes.map(_.className).sorted.map(implicitForNodeType).mkString(lineSeparator)
 
       val implicitsForNodeBaseTypeTraversals =
-        schema.nodeBaseTypes.map(_.className).sorted.map(implicitForNodeType).mkString("\n  ")
+        schema.nodeBaseTypes.map(_.className).sorted.map(implicitForNodeType).mkString(lineSeparator)
 
       s"""package $traversalsPackage
          |
@@ -1229,7 +1229,7 @@ class CodeGen(schema: Schema) {
            |  */ ${docAnnotationMaybe(customStepDoc)}
            |def $customStepName: Traversal[${neighbor.className}] =
            |  traversal.$mapOrFlatMap(_.$customStepName)
-           |""".stripMargin.replace("\n", "\n  ")
+           |""".stripMargin
       }
     }
 
@@ -1246,304 +1246,302 @@ class CodeGen(schema: Schema) {
         }
 
         val filterStepsForSingleString =
-          s"""  /**
-             |    * Traverse to nodes where the $nameCamelCase matches the regular expression `value`
-             |    * */
-             |  def $nameCamelCase(pattern: $baseType): Traversal[NodeType] = {
-             |    if(!Misc.isRegex(pattern)){
-             |      traversal.filter{node => node.${nameCamelCase} == pattern}
-             |    } else {
-             |      overflowdb.traversal.filter.StringPropertyFilter.regexp(traversal)(_.$nameCamelCase, pattern)
-             |    }
+          s"""/**
+             |  * Traverse to nodes where the $nameCamelCase matches the regular expression `value`
+             |  * */
+             |def $nameCamelCase(pattern: $baseType): Traversal[NodeType] = {
+             |  if(!Misc.isRegex(pattern)){
+             |    traversal.filter{node => node.${nameCamelCase} == pattern}
+             |  } else {
+             |    overflowdb.traversal.filter.StringPropertyFilter.regexp(traversal)(_.$nameCamelCase, pattern)
              |  }
+             |}
              |
-             |  /**
-             |    * Traverse to nodes where the $nameCamelCase matches at least one of the regular expressions in `values`
-             |    * */
-             |  def $nameCamelCase(patterns: $baseType*): Traversal[NodeType] =
-             |    overflowdb.traversal.filter.StringPropertyFilter.regexpMultiple(traversal)(_.$nameCamelCase, patterns)
+             |/**
+             |  * Traverse to nodes where the $nameCamelCase matches at least one of the regular expressions in `values`
+             |  * */
+             |def $nameCamelCase(patterns: $baseType*): Traversal[NodeType] =
+             |  overflowdb.traversal.filter.StringPropertyFilter.regexpMultiple(traversal)(_.$nameCamelCase, patterns)
              |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase matches `value` exactly.
-             |    * */
-             |  def ${nameCamelCase}Exact(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{node => node.${nameCamelCase} == value}
+             |/**
+             |  * Traverse to nodes where $nameCamelCase matches `value` exactly.
+             |  * */
+             |def ${nameCamelCase}Exact(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{node => node.${nameCamelCase} == value}
              |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase matches one of the elements in `values` exactly.
-             |    * */
-             |  def ${nameCamelCase}Exact(values: $baseType*): Traversal[NodeType] = {
-             |    val vset = values.to(Set)
-             |    traversal.filter{node => vset.contains(node.${nameCamelCase})}
+             |/**
+             |  * Traverse to nodes where $nameCamelCase matches one of the elements in `values` exactly.
+             |  * */
+             |def ${nameCamelCase}Exact(values: $baseType*): Traversal[NodeType] = {
+             |  val vset = values.to(Set)
+             |  traversal.filter{node => vset.contains(node.${nameCamelCase})}
+             |}
+             |
+             |/**
+             |  * Traverse to nodes where $nameCamelCase does not match the regular expression `value`.
+             |  * */
+             |def ${nameCamelCase}Not(pattern: $baseType): Traversal[NodeType] = {
+             |  if(!Misc.isRegex(pattern)){
+             |    traversal.filter{node => node.${nameCamelCase} != pattern}
+             |  } else {
+             |    overflowdb.traversal.filter.StringPropertyFilter.regexpNot(traversal)(_.$nameCamelCase, pattern)
              |  }
+             |}
              |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase does not match the regular expression `value`.
-             |    * */
-             |  def ${nameCamelCase}Not(pattern: $baseType): Traversal[NodeType] = {
-             |    if(!Misc.isRegex(pattern)){
-             |      traversal.filter{node => node.${nameCamelCase} != pattern}
-             |    } else {
-             |      overflowdb.traversal.filter.StringPropertyFilter.regexpNot(traversal)(_.$nameCamelCase, pattern)
-             |    }
-             |  }
-             |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase does not match any of the regular expressions in `values`.
-             |    * */
-             |  def ${nameCamelCase}Not(patterns: $baseType*): Traversal[NodeType] = {
-             |      overflowdb.traversal.filter.StringPropertyFilter.regexpNotMultiple(traversal)(_.$nameCamelCase, patterns)
-             |   }
-             |
+             |/**
+             |  * Traverse to nodes where $nameCamelCase does not match any of the regular expressions in `values`.
+             |  * */
+             |def ${nameCamelCase}Not(patterns: $baseType*): Traversal[NodeType] = {
+             |    overflowdb.traversal.filter.StringPropertyFilter.regexpNotMultiple(traversal)(_.$nameCamelCase, patterns)
+             | }
              |""".stripMargin
 
         val filterStepsForOptionalString =
-          s"""  /**
-             |    * Traverse to nodes where the $nameCamelCase matches the regular expression `value`
-             |    * */
-             |  def $nameCamelCase(pattern: $baseType): Traversal[NodeType] = {
-             |    if(!Misc.isRegex(pattern)){
-             |      traversal.filter{node => node.$nameCamelCase.isDefined && node.${nameCamelCase}.get == pattern}
-             |    } else {
-             |      overflowdb.traversal.filter.StringPropertyFilter.regexp(traversal.filter(_.$nameCamelCase.isDefined))(_.$nameCamelCase.get, pattern)
-             |    }
+          s"""/**
+             |  * Traverse to nodes where the $nameCamelCase matches the regular expression `value`
+             |  * */
+             |def $nameCamelCase(pattern: $baseType): Traversal[NodeType] = {
+             |  if(!Misc.isRegex(pattern)){
+             |    traversal.filter{node => node.$nameCamelCase.isDefined && node.${nameCamelCase}.get == pattern}
+             |  } else {
+             |    overflowdb.traversal.filter.StringPropertyFilter.regexp(traversal.filter(_.$nameCamelCase.isDefined))(_.$nameCamelCase.get, pattern)
              |  }
+             |}
              |
-             |  /**
-             |    * Traverse to nodes where the $nameCamelCase matches at least one of the regular expressions in `values`
-             |    * */
-             |  def $nameCamelCase(patterns: $baseType*): Traversal[NodeType] = {
-             |    overflowdb.traversal.filter.StringPropertyFilter.regexpMultiple(traversal.filter(_.$nameCamelCase.isDefined))(_.$nameCamelCase.get, patterns)
+             |/**
+             |  * Traverse to nodes where the $nameCamelCase matches at least one of the regular expressions in `values`
+             |  * */
+             |def $nameCamelCase(patterns: $baseType*): Traversal[NodeType] = {
+             |  overflowdb.traversal.filter.StringPropertyFilter.regexpMultiple(traversal.filter(_.$nameCamelCase.isDefined))(_.$nameCamelCase.get, patterns)
+             |}
+             |
+             |/**
+             |  * Traverse to nodes where $nameCamelCase matches `value` exactly.
+             |  * */
+             |def ${nameCamelCase}Exact(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{node => node.$nameCamelCase.isDefined && node.${nameCamelCase}.get == value}
+             |
+             |/**
+             |  * Traverse to nodes where $nameCamelCase matches one of the elements in `values` exactly.
+             |  * */
+             |def ${nameCamelCase}Exact(values: $baseType*): Traversal[NodeType] = {
+             |  val vset = values.to(Set)
+             |  traversal.filter{node => node.$nameCamelCase.isDefined && vset.contains(node.${nameCamelCase}.get)}
+             |}
+             |
+             |/**
+             |  * Traverse to nodes where $nameCamelCase does not match the regular expression `value`.
+             |  * */
+             |def ${nameCamelCase}Not(pattern: $baseType): Traversal[NodeType] = {
+             |  if(!Misc.isRegex(pattern)){
+             |    traversal.filter{node => node.$nameCamelCase.isEmpty || node.${nameCamelCase}.get != pattern}
+             |  } else {
+             |    overflowdb.traversal.filter.StringPropertyFilter.regexpNot(traversal.filter(_.$nameCamelCase.isDefined))(_.$nameCamelCase.get, pattern)
              |  }
+             |}
              |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase matches `value` exactly.
-             |    * */
-             |  def ${nameCamelCase}Exact(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{node => node.$nameCamelCase.isDefined && node.${nameCamelCase}.get == value}
-             |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase matches one of the elements in `values` exactly.
-             |    * */
-             |  def ${nameCamelCase}Exact(values: $baseType*): Traversal[NodeType] = {
-             |    val vset = values.to(Set)
-             |    traversal.filter{node => node.$nameCamelCase.isDefined && vset.contains(node.${nameCamelCase}.get)}
-             |  }
-             |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase does not match the regular expression `value`.
-             |    * */
-             |  def ${nameCamelCase}Not(pattern: $baseType): Traversal[NodeType] = {
-             |    if(!Misc.isRegex(pattern)){
-             |      traversal.filter{node => node.$nameCamelCase.isEmpty || node.${nameCamelCase}.get != pattern}
-             |    } else {
-             |      overflowdb.traversal.filter.StringPropertyFilter.regexpNot(traversal.filter(_.$nameCamelCase.isDefined))(_.$nameCamelCase.get, pattern)
-             |    }
-             |  }
-             |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase does not match any of the regular expressions in `values`.
-             |    * */
-             |  def ${nameCamelCase}Not(patterns: $baseType*): Traversal[NodeType] = {
-             |    overflowdb.traversal.filter.StringPropertyFilter.regexpNotMultiple(traversal.filter(_.$nameCamelCase.isDefined))(_.$nameCamelCase.get, patterns)
-             |   }
-             |
+             |/**
+             |  * Traverse to nodes where $nameCamelCase does not match any of the regular expressions in `values`.
+             |  * */
+             |def ${nameCamelCase}Not(patterns: $baseType*): Traversal[NodeType] = {
+             |  overflowdb.traversal.filter.StringPropertyFilter.regexpNotMultiple(traversal.filter(_.$nameCamelCase.isDefined))(_.$nameCamelCase.get, patterns)
+             | }
              |""".stripMargin
 
         val filterStepsForSingleBoolean =
-          s"""  /**
-             |    * Traverse to nodes where the $nameCamelCase equals the given `value`
-             |    * */
-             |  def $nameCamelCase(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{_.$nameCamelCase == value}
+          s"""/**
+             |  * Traverse to nodes where the $nameCamelCase equals the given `value`
+             |  * */
+             |def $nameCamelCase(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{_.$nameCamelCase == value}
              |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase is not equal to the given `value`.
-             |    * */
-             |  def ${nameCamelCase}Not(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{_.$nameCamelCase != value}
+             |/**
+             |  * Traverse to nodes where $nameCamelCase is not equal to the given `value`.
+             |  * */
+             |def ${nameCamelCase}Not(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{_.$nameCamelCase != value}
              |""".stripMargin
 
         val filterStepsForOptionalBoolean =
-          s"""  /**
-             |    * Traverse to nodes where the $nameCamelCase equals the given `value`
-             |    * */
-             |  def $nameCamelCase(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{node => node.${nameCamelCase}.isDefined && node.$nameCamelCase.get == value}
+          s"""/**
+             |  * Traverse to nodes where the $nameCamelCase equals the given `value`
+             |  * */
+             |def $nameCamelCase(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{node => node.${nameCamelCase}.isDefined && node.$nameCamelCase.get == value}
              |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase is not equal to the given `value`.
-             |    * */
-             |  def ${nameCamelCase}Not(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{node => !node.${nameCamelCase}.isDefined || node.$nameCamelCase.get == value}
+             |/**
+             |  * Traverse to nodes where $nameCamelCase is not equal to the given `value`.
+             |  * */
+             |def ${nameCamelCase}Not(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{node => !node.${nameCamelCase}.isDefined || node.$nameCamelCase.get == value}
              |""".stripMargin
 
         val filterStepsForSingleInt =
-          s"""  /**
-             |    * Traverse to nodes where the $nameCamelCase equals the given `value`
-             |    * */
-             |  def $nameCamelCase(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{_.$nameCamelCase == value}
+          s"""/**
+             |  * Traverse to nodes where the $nameCamelCase equals the given `value`
+             |  * */
+             |def $nameCamelCase(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{_.$nameCamelCase == value}
              |
-             |  /**
-             |    * Traverse to nodes where the $nameCamelCase equals at least one of the given `values`
-             |    * */
-             |  def $nameCamelCase(values: $baseType*): Traversal[NodeType] = {
-             |    val vset = values.toSet
-             |    traversal.filter{node => vset.contains(node.$nameCamelCase)}
-             |  }
+             |/**
+             |  * Traverse to nodes where the $nameCamelCase equals at least one of the given `values`
+             |  * */
+             |def $nameCamelCase(values: $baseType*): Traversal[NodeType] = {
+             |  val vset = values.toSet
+             |  traversal.filter{node => vset.contains(node.$nameCamelCase)}
+             |}
              |
-             |  /**
-             |    * Traverse to nodes where the $nameCamelCase is greater than the given `value`
-             |    * */
-             |  def ${nameCamelCase}Gt(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{_.$nameCamelCase > value}
+             |/**
+             |  * Traverse to nodes where the $nameCamelCase is greater than the given `value`
+             |  * */
+             |def ${nameCamelCase}Gt(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{_.$nameCamelCase > value}
              |
-             |  /**
-             |    * Traverse to nodes where the $nameCamelCase is greater than or equal the given `value`
-             |    * */
-             |  def ${nameCamelCase}Gte(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{_.$nameCamelCase >= value}
+             |/**
+             |  * Traverse to nodes where the $nameCamelCase is greater than or equal the given `value`
+             |  * */
+             |def ${nameCamelCase}Gte(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{_.$nameCamelCase >= value}
              |
-             |  /**
-             |    * Traverse to nodes where the $nameCamelCase is less than the given `value`
-             |    * */
-             |  def ${nameCamelCase}Lt(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{_.$nameCamelCase < value}
+             |/**
+             |  * Traverse to nodes where the $nameCamelCase is less than the given `value`
+             |  * */
+             |def ${nameCamelCase}Lt(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{_.$nameCamelCase < value}
              |
-             |  /**
-             |    * Traverse to nodes where the $nameCamelCase is less than or equal the given `value`
-             |    * */
-             |  def ${nameCamelCase}Lte(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{_.$nameCamelCase <= value}
+             |/**
+             |  * Traverse to nodes where the $nameCamelCase is less than or equal the given `value`
+             |  * */
+             |def ${nameCamelCase}Lte(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{_.$nameCamelCase <= value}
              |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase is not equal to the given `value`.
-             |    * */
-             |  def ${nameCamelCase}Not(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{_.$nameCamelCase != value}
+             |/**
+             |  * Traverse to nodes where $nameCamelCase is not equal to the given `value`.
+             |  * */
+             |def ${nameCamelCase}Not(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{_.$nameCamelCase != value}
              |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase is not equal to any of the given `values`.
-             |    * */
-             |  def ${nameCamelCase}Not(values: $baseType*): Traversal[NodeType] = {
-             |    val vset = values.toSet
-             |    traversal.filter{node => !vset.contains(node.$nameCamelCase)}
-             |  }
+             |/**
+             |  * Traverse to nodes where $nameCamelCase is not equal to any of the given `values`.
+             |  * */
+             |def ${nameCamelCase}Not(values: $baseType*): Traversal[NodeType] = {
+             |  val vset = values.toSet
+             |  traversal.filter{node => !vset.contains(node.$nameCamelCase)}
+             |}
              |""".stripMargin
 
         val filterStepsForOptionalInt =
-          s"""  /**
-             |    * Traverse to nodes where the $nameCamelCase equals the given `value`
-             |    * */
-             |  def $nameCamelCase(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{node => node.$nameCamelCase.isDefined && node.$nameCamelCase.get == value}
+          s"""/**
+             |  * Traverse to nodes where the $nameCamelCase equals the given `value`
+             |  * */
+             |def $nameCamelCase(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{node => node.$nameCamelCase.isDefined && node.$nameCamelCase.get == value}
              |
-             |  /**
-             |    * Traverse to nodes where the $nameCamelCase equals at least one of the given `values`
-             |    * */
-             |  def $nameCamelCase(values: $baseType*): Traversal[NodeType] = {
-             |    val vset = values.toSet
-             |    traversal.filter{node => node.$nameCamelCase.isDefined && vset.contains(node.$nameCamelCase.get)}
-             |  }
+             |/**
+             |  * Traverse to nodes where the $nameCamelCase equals at least one of the given `values`
+             |  * */
+             |def $nameCamelCase(values: $baseType*): Traversal[NodeType] = {
+             |  val vset = values.toSet
+             |  traversal.filter{node => node.$nameCamelCase.isDefined && vset.contains(node.$nameCamelCase.get)}
+             |}
              |
-             |  /**
-             |    * Traverse to nodes where the $nameCamelCase is greater than the given `value`
-             |    * */
-             |  def ${nameCamelCase}Gt(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{node => node.$nameCamelCase.isDefined && node.$nameCamelCase.get > value}
+             |/**
+             |  * Traverse to nodes where the $nameCamelCase is greater than the given `value`
+             |  * */
+             |def ${nameCamelCase}Gt(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{node => node.$nameCamelCase.isDefined && node.$nameCamelCase.get > value}
              |
-             |  /**
-             |    * Traverse to nodes where the $nameCamelCase is greater than or equal the given `value`
-             |    * */
-             |  def ${nameCamelCase}Gte(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{node => node.$nameCamelCase.isDefined && node.$nameCamelCase.get >= value}
+             |/**
+             |  * Traverse to nodes where the $nameCamelCase is greater than or equal the given `value`
+             |  * */
+             |def ${nameCamelCase}Gte(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{node => node.$nameCamelCase.isDefined && node.$nameCamelCase.get >= value}
              |
-             |  /**
-             |    * Traverse to nodes where the $nameCamelCase is less than the given `value`
-             |    * */
-             |  def ${nameCamelCase}Lt(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{node => node.$nameCamelCase.isDefined && node.$nameCamelCase.get < value}
+             |/**
+             |  * Traverse to nodes where the $nameCamelCase is less than the given `value`
+             |  * */
+             |def ${nameCamelCase}Lt(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{node => node.$nameCamelCase.isDefined && node.$nameCamelCase.get < value}
              |
-             |  /**
-             |    * Traverse to nodes where the $nameCamelCase is less than or equal the given `value`
-             |    * */
-             |  def ${nameCamelCase}Lte(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{node => node.$nameCamelCase.isDefined && node.$nameCamelCase.get <= value}
+             |/**
+             |  * Traverse to nodes where the $nameCamelCase is less than or equal the given `value`
+             |  * */
+             |def ${nameCamelCase}Lte(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{node => node.$nameCamelCase.isDefined && node.$nameCamelCase.get <= value}
              |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase is not equal to the given `value`.
-             |    * */
-             |  def ${nameCamelCase}Not(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{node => !node.$nameCamelCase.isDefined || node.$nameCamelCase.get != value}
+             |/**
+             |  * Traverse to nodes where $nameCamelCase is not equal to the given `value`.
+             |  * */
+             |def ${nameCamelCase}Not(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{node => !node.$nameCamelCase.isDefined || node.$nameCamelCase.get != value}
              |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase is not equal to any of the given `values`.
-             |    * */
-             |  def ${nameCamelCase}Not(values: $baseType*): Traversal[NodeType] = {
-             |    val vset = values.toSet
-             |    traversal.filter{node => !node.$nameCamelCase.isDefined || !vset.contains(node.$nameCamelCase.get)}
-             |  }
+             |/**
+             |  * Traverse to nodes where $nameCamelCase is not equal to any of the given `values`.
+             |  * */
+             |def ${nameCamelCase}Not(values: $baseType*): Traversal[NodeType] = {
+             |  val vset = values.toSet
+             |  traversal.filter{node => !node.$nameCamelCase.isDefined || !vset.contains(node.$nameCamelCase.get)}
+             |}
              |""".stripMargin
 
         val filterStepsGenericSingle =
-          s"""  /**
-             |    * Traverse to nodes where the $nameCamelCase equals the given `value`
-             |    * */
-             |  def $nameCamelCase(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{_.$nameCamelCase == value}
+          s"""/**
+             |  * Traverse to nodes where the $nameCamelCase equals the given `value`
+             |  * */
+             |def $nameCamelCase(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{_.$nameCamelCase == value}
              |
-             |  /**
-             |    * Traverse to nodes where the $nameCamelCase equals at least one of the given `values`
-             |    * */
-             |  def $nameCamelCase(values: $baseType*): Traversal[NodeType] = {
-             |    val vset = values.toSet
-             |    traversal.filter{node => !vset.contains(node.$nameCamelCase)}
-             |  }
+             |/**
+             |  * Traverse to nodes where the $nameCamelCase equals at least one of the given `values`
+             |  * */
+             |def $nameCamelCase(values: $baseType*): Traversal[NodeType] = {
+             |  val vset = values.toSet
+             |  traversal.filter{node => !vset.contains(node.$nameCamelCase)}
+             |}
              |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase is not equal to the given `value`.
-             |    * */
-             |  def ${nameCamelCase}Not(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{_.$nameCamelCase != value}
+             |/**
+             |  * Traverse to nodes where $nameCamelCase is not equal to the given `value`.
+             |  * */
+             |def ${nameCamelCase}Not(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{_.$nameCamelCase != value}
              |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase is not equal to any of the given `values`.
-             |    * */
-             |  def ${nameCamelCase}Not(values: $baseType*): Traversal[NodeType] = {
-             |    val vset = values.toSet
-             |    traversal.filter{node => !vset.contains(node.$nameCamelCase)}
-             |  }
+             |/**
+             |  * Traverse to nodes where $nameCamelCase is not equal to any of the given `values`.
+             |  * */
+             |def ${nameCamelCase}Not(values: $baseType*): Traversal[NodeType] = {
+             |  val vset = values.toSet
+             |  traversal.filter{node => !vset.contains(node.$nameCamelCase)}
+             |}
              |""".stripMargin
 
         val filterStepsGenericOption =
-          s"""  /**
-             |    * Traverse to nodes where the $nameCamelCase equals the given `value`
-             |    * */
-             |  def $nameCamelCase(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{node => node.$nameCamelCase.isDefined && node.$nameCamelCase.get == value}
+          s"""/**
+             |  * Traverse to nodes where the $nameCamelCase equals the given `value`
+             |  * */
+             |def $nameCamelCase(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{node => node.$nameCamelCase.isDefined && node.$nameCamelCase.get == value}
              |
-             |  /**
-             |    * Traverse to nodes where the $nameCamelCase equals at least one of the given `values`
-             |    * */
-             |  def $nameCamelCase(values: $baseType*): Traversal[NodeType] = {
-             |    val vset = values.toSet
-             |    traversal.filter{node => node.$nameCamelCase.isDefined && !vset.contains(node.$nameCamelCase.get)}
-             |  }
+             |/**
+             |  * Traverse to nodes where the $nameCamelCase equals at least one of the given `values`
+             |  * */
+             |def $nameCamelCase(values: $baseType*): Traversal[NodeType] = {
+             |  val vset = values.toSet
+             |  traversal.filter{node => node.$nameCamelCase.isDefined && !vset.contains(node.$nameCamelCase.get)}
+             |}
              |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase is not equal to the given `value`.
-             |    * */
-             |  def ${nameCamelCase}Not(value: $baseType): Traversal[NodeType] =
-             |    traversal.filter{node => !node.$nameCamelCase.isDefined || node.$nameCamelCase.get != value}
+             |/**
+             |  * Traverse to nodes where $nameCamelCase is not equal to the given `value`.
+             |  * */
+             |def ${nameCamelCase}Not(value: $baseType): Traversal[NodeType] =
+             |  traversal.filter{node => !node.$nameCamelCase.isDefined || node.$nameCamelCase.get != value}
              |
-             |  /**
-             |    * Traverse to nodes where $nameCamelCase is not equal to any of the given `values`.
-             |    * */
-             |  def ${nameCamelCase}Not(values: $baseType*): Traversal[NodeType] = {
-             |    val vset = values.toSet
-             |    traversal.filter{node => !node.$nameCamelCase.isDefined || !vset.contains(node.$nameCamelCase.get)}
-             |  }
+             |/**
+             |  * Traverse to nodes where $nameCamelCase is not equal to any of the given `values`.
+             |  * */
+             |def ${nameCamelCase}Not(values: $baseType*): Traversal[NodeType] = {
+             |  val vset = values.toSet
+             |  traversal.filter{node => !node.$nameCamelCase.isDefined || !vset.contains(node.$nameCamelCase.get)}
+             |}
              |""".stripMargin
 
         val filterSteps = (cardinality, property.valueType) match {
@@ -1559,11 +1557,11 @@ class CodeGen(schema: Schema) {
           case _ => ""
         }
 
-        s"""  /** Traverse to $nameCamelCase property */
-           |  def $nameCamelCase: Traversal[$baseType] =
-           |    traversal.$mapOrFlatMap(_.$nameCamelCase)
+        s"""/** Traverse to $nameCamelCase property */
+           |def $nameCamelCase: Traversal[$baseType] =
+           |  traversal.$mapOrFlatMap(_.$nameCamelCase)
            |
-           |  $filterSteps
+           |$filterSteps
            |""".stripMargin
       }
     }
@@ -1581,9 +1579,9 @@ class CodeGen(schema: Schema) {
          |/** Traversal steps for $className */
          |class ${className}TraversalExtGen[NodeType <: $className](val traversal: IterableOnce[NodeType]) extends AnyVal {
          |
-         |${customStepNameTraversals.mkString("\n  ")}
+         |${customStepNameTraversals.mkString(System.lineSeparator)}
          |
-         |${propertyTraversals.mkString("\n")}
+         |${propertyTraversals.mkString(System.lineSeparator)}
          |
          |}""".stripMargin
     }
@@ -1666,11 +1664,11 @@ class CodeGen(schema: Schema) {
             key.cardinality match {
               case Cardinality.One(default) =>
                 val isDefaultValueImpl = defaultValueCheckImpl(memberName, default)
-                s"""  if (!($isDefaultValueImpl)) { res += "${key.name}" -> $memberName }"""
+                s"""if (!($isDefaultValueImpl)) { res += "${key.name}" -> $memberName }"""
               case Cardinality.ZeroOrOne =>
-                s"""  $memberName.map { value => res += "${key.name}" -> value }"""
+                s"""$memberName.map { value => res += "${key.name}" -> value }"""
               case Cardinality.List =>
-                s"""  if ($memberName != null && $memberName.nonEmpty) { res += "${key.name}" -> $memberName }"""
+                s"""if ($memberName != null && $memberName.nonEmpty) { res += "${key.name}" -> $memberName }"""
             }
           }
         val putRefsImpl = nodeType.containedNodes.map { key =>
@@ -1679,20 +1677,20 @@ class CodeGen(schema: Schema) {
           key.cardinality match {
             case Cardinality.One(default) =>
               val isDefaultValueImpl = defaultValueCheckImpl(memberName, default)
-              s"""  if (!($isDefaultValueImpl)) { res += "$memberName" -> $memberName }"""
+              s"""if (!($isDefaultValueImpl)) { res += "$memberName" -> $memberName }"""
             case Cardinality.ZeroOrOne =>
-              s"""  $memberName.map { value => res += "$memberName" -> value }"""
+              s"""$memberName.map { value => res += "$memberName" -> value }"""
             case Cardinality.List =>
-              s"""  if ($memberName != null && $memberName.nonEmpty) { res += "$memberName" -> $memberName }"""
+              s"""if ($memberName != null && $memberName.nonEmpty) { res += "$memberName" -> $memberName }"""
           }
         }
 
         val propertiesImpl = {
           val lines = putKeysImpl ++ putRefsImpl
           if (lines.nonEmpty) {
-            s"""  var res = Map[String, Any]()
-               |${lines.mkString("\n")}
-               |  res""".stripMargin
+            s"""var res = Map[String, Any]()
+               |${lines.mkString(lineSeparator)}
+               |res""".stripMargin
           } else {
             "Map.empty"
           }
@@ -1733,12 +1731,12 @@ class CodeGen(schema: Schema) {
                  |}
                  |""".stripMargin
           }
-      }.mkString("\n").replaceAll("\n", "\n  ")
+      }.mkString(lineSeparator)
 
       val copyFieldsImpl = fieldDescriptions.map { field =>
         val memberName = field.name
         s"newInstance.$memberName = this.$memberName"
-      }.mkString("\n    ")
+      }.mkString(lineSeparator)
 
       val classNameNewNode = s"New$nodeClassName"
 
@@ -1746,11 +1744,11 @@ class CodeGen(schema: Schema) {
       val productElementAccessors = productElements.map {
         case (fieldDescription, index) =>
           s"case $index => this.${fieldDescription.name}"
-      }.mkString("\n")
+      }.mkString(lineSeparator)
       val productElementNames = productElements.map {
         case (fieldDescription, index) =>
           s"""case $index => "${fieldDescription.name}""""
-      }.mkString("\n")
+      }.mkString(lineSeparator)
 
       s"""object $classNameNewNode {
          |  def apply(): $classNameNewNode = new $classNameNewNode
@@ -1798,7 +1796,7 @@ class CodeGen(schema: Schema) {
     outfile.createFile()
     val src = schema.nodeTypes.map { nodeType =>
       generateNewNodeSource(nodeType, nodeType.properties)
-    }.mkString("\n")
+    }.mkString(lineSeparator)
     outfile.write(s"""$staticHeader
                      |$src
                      |""".stripMargin)

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -17,7 +17,7 @@ class CodeGen(schema: Schema) {
   val traversalsPackage = s"$basePackage.traversal"
 
   private var enableScalafmt = true
-  private var scalafmtConfig: Option[java.io.File] = None
+  private var scalafmtConfig: Option[File] = None
 
   def disableScalafmt: this.type = {
     enableScalafmt = false
@@ -25,8 +25,8 @@ class CodeGen(schema: Schema) {
   }
 
   /** replace entire default scalafmt config (from Formatter.defaultScalafmtConfig) with custom config */
-  def withScalafmtConfig(config: java.io.File): this.type = {
-    this.scalafmtConfig = Option(config)
+  def withScalafmtConfig(file: java.io.File): this.type = {
+    this.scalafmtConfig = Option(file.toScala)
     this
   }
 
@@ -42,11 +42,11 @@ class CodeGen(schema: Schema) {
       writeNewNodeFile(_outputDir)
     println(s"generated ${results.size} files in ${_outputDir}")
 
-    val resultsAsJava = results.map(_.toJava)
     if (enableScalafmt) {
-      Formatter.run(resultsAsJava, scalafmtConfig)
+      val scalaSourceFiles = results.filter(_.extension == Some(".scala"))
+      Formatter.run(scalaSourceFiles, scalafmtConfig)
     }
-    resultsAsJava
+    results.map(_.toJava)
   }
 
   /* to provide feedback for potential schema optimisation: no need to redefine properties if they are already

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -930,7 +930,7 @@ class CodeGen(schema: Schema) {
             s"""def ${containedNode.localName}: collection.immutable.IndexedSeq[${containedNode.nodeType.className}] = get().${containedNode.localName}"""
         }
 
-        s"""${docAnnotationMaybe(containedNode.comment, indent = "    ")}
+        s"""${docAnnotationMaybe(containedNode.comment)}
            |    $src
            |""".stripMargin
       }.mkString("\n  ")

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -16,6 +16,20 @@ class CodeGen(schema: Schema) {
   val edgesPackage = s"$basePackage.edges"
   val traversalsPackage = s"$basePackage.traversal"
 
+  private var enableScalafmt = true
+  private var scalafmtConfig: Option[java.io.File] = None
+
+  def disableScalafmt: this.type = {
+    enableScalafmt = false
+    this
+  }
+
+  /** replace entire default scalafmt config (from Formatter.defaultScalafmtConfig) with custom config */
+  def withScalafmtConfig(config: java.io.File): this.type = {
+    this.scalafmtConfig = Option(config)
+    this
+  }
+
   def run(outputDir: java.io.File): Seq[java.io.File] = {
     warnForDuplicatePropertyDefinitions()
     val _outputDir = outputDir.toScala
@@ -29,7 +43,7 @@ class CodeGen(schema: Schema) {
     println(s"generated ${results.size} files in ${_outputDir}")
 
     val resultsAsJava = results.map(_.toJava)
-    Formatter.apply(resultsAsJava)
+    if (enableScalafmt) Formatter.apply(resultsAsJava)
     resultsAsJava
   }
 

--- a/codegen/src/main/scala/overflowdb/codegen/Formatter.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/Formatter.scala
@@ -1,9 +1,6 @@
 package overflowdb.codegen
 
-import better.files.File.temporaryFile
-import better.files.{Dispose, FileExtensions}
-
-import java.io.File
+import better.files._
 import java.nio.file.{Files, Path}
 import org.scalafmt.interfaces.Scalafmt
 
@@ -15,20 +12,19 @@ object Formatter {
       |maxColumn=120
       |""".stripMargin
 
-  def run(sourceFiles: Seq[java.io.File], scalafmtConfig: Option[File]): Unit = {
-    val configFile = scalafmtConfig.getOrElse {
-      val tmpFile = Files.createTempFile("overflowdb-scalafmt", "conf").toFile
-      tmpFile.toScala.write(defaultScalafmtConfig)
-      tmpFile
-    }
+  def run(sourceFiles: Seq[File], scalafmtConfig: Option[File]): Unit = {
+    val configFile: File = scalafmtConfig.getOrElse(
+      Files
+        .createTempFile("overflowdb-scalafmt", "conf")
+        .toFile
+        .toScala
+        .write(defaultScalafmtConfig)
+    )
     
     val scalafmt = Scalafmt.create(getClass.getClassLoader)
-    val scalafmtSession = scalafmt.createSession(configFile.toPath)
+    val scalafmtSession = scalafmt.createSession(configFile.path)
 
-    sourceFiles
-      .map(_.toScala)
-      .filter(_.extension == Some(".scala"))
-      .foreach { file =>
+    sourceFiles.foreach { file =>
       val originalSource = file.lines.mkString("\n")
       val formattedSource = scalafmtSession.format(file.path, originalSource)
       file.writeText(formattedSource)

--- a/codegen/src/main/scala/overflowdb/codegen/Formatter.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/Formatter.scala
@@ -15,7 +15,7 @@ object Formatter {
   def run(sourceFiles: Seq[File], scalafmtConfig: Option[File]): Unit = {
     val configFile: File = scalafmtConfig.getOrElse(
       Files
-        .createTempFile("overflowdb-scalafmt", "conf")
+        .createTempFile("overflowdb-scalafmt", ".conf")
         .toFile
         .toScala
         .write(defaultScalafmtConfig)

--- a/codegen/src/main/scala/overflowdb/codegen/Formatter.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/Formatter.scala
@@ -25,7 +25,10 @@ object Formatter {
     val scalafmt = Scalafmt.create(getClass.getClassLoader)
     val scalafmtSession = scalafmt.createSession(configFile.toPath)
 
-    sourceFiles.map(_.toScala).foreach { file =>
+    sourceFiles
+      .map(_.toScala)
+      .filter(_.extension == Some(".scala"))
+      .foreach { file =>
       val originalSource = file.lines.mkString("\n")
       val formattedSource = scalafmtSession.format(file.path, originalSource)
       file.writeText(formattedSource)

--- a/codegen/src/main/scala/overflowdb/codegen/Formatter.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/Formatter.scala
@@ -1,0 +1,32 @@
+package overflowdb.codegen
+
+import better.files.File.usingTemporaryFile
+import better.files._
+import java.nio.file.Path
+import org.scalafmt.interfaces.Scalafmt
+
+object Formatter {
+  val defaultScalafmtConfig = Map(
+    "version" -> "3.4.3",
+    "runner.dialect" -> "scala213",
+    "align.preset" -> "some",
+    "maxColumn" -> "120",
+  )
+
+  def apply(sourceFiles: Seq[java.io.File], scalafmtConfig: Map[String, String] = defaultScalafmtConfig): Unit = {
+    val scalafmt = Scalafmt.create(getClass.getClassLoader)
+      usingTemporaryFile("overflowdb-scalafmt", "conf") { configFile =>
+        val scalafmtConfigString = scalafmtConfig.map { case (key, value) => s"$key = $value" }.mkString("\n")
+        configFile.write(scalafmtConfigString)
+        val scalafmtSession = scalafmt.createSession(configFile.path)
+
+        sourceFiles.map(_.toScala).foreach { file =>
+          val originalSource = file.lines.mkString("\n")
+          val formattedSource = scalafmtSession.format(file.path, originalSource)
+          file.writeText(formattedSource)
+        }
+      }
+
+  }
+
+}

--- a/codegen/src/main/scala/overflowdb/codegen/Formatter.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/Formatter.scala
@@ -1,32 +1,35 @@
 package overflowdb.codegen
 
-import better.files.File.usingTemporaryFile
-import better.files._
-import java.nio.file.Path
+import better.files.File.temporaryFile
+import better.files.{Dispose, FileExtensions}
+
+import java.io.File
+import java.nio.file.{Files, Path}
 import org.scalafmt.interfaces.Scalafmt
 
 object Formatter {
-  val defaultScalafmtConfig = Map(
-    "version" -> "3.4.3",
-    "runner.dialect" -> "scala213",
-    "align.preset" -> "some",
-    "maxColumn" -> "120",
-  )
+  val defaultScalafmtConfig = """
+      |version=3.4.3
+      |runner.dialect=scala213
+      |align.preset=some
+      |maxColumn=120
+      |""".stripMargin
 
-  def apply(sourceFiles: Seq[java.io.File], scalafmtConfig: Map[String, String] = defaultScalafmtConfig): Unit = {
+  def run(sourceFiles: Seq[java.io.File], scalafmtConfig: Option[File]): Unit = {
+    val configFile = scalafmtConfig.getOrElse {
+      val tmpFile = Files.createTempFile("overflowdb-scalafmt", "conf").toFile
+      tmpFile.toScala.write(defaultScalafmtConfig)
+      tmpFile
+    }
+    
     val scalafmt = Scalafmt.create(getClass.getClassLoader)
-      usingTemporaryFile("overflowdb-scalafmt", "conf") { configFile =>
-        val scalafmtConfigString = scalafmtConfig.map { case (key, value) => s"$key = $value" }.mkString("\n")
-        configFile.write(scalafmtConfigString)
-        val scalafmtSession = scalafmt.createSession(configFile.path)
+    val scalafmtSession = scalafmt.createSession(configFile.toPath)
 
-        sourceFiles.map(_.toScala).foreach { file =>
-          val originalSource = file.lines.mkString("\n")
-          val formattedSource = scalafmtSession.format(file.path, originalSource)
-          file.writeText(formattedSource)
-        }
-      }
-
+    sourceFiles.map(_.toScala).foreach { file =>
+      val originalSource = file.lines.mkString("\n")
+      val formattedSource = scalafmtSession.format(file.path, originalSource)
+      file.writeText(formattedSource)
+    }
   }
 
 }

--- a/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -1,5 +1,6 @@
 package overflowdb.codegen
 
+import java.lang.System.lineSeparator
 import overflowdb.algorithm.LowestCommonAncestors
 import overflowdb.schema._
 import overflowdb.schema.Property.ValueType
@@ -183,15 +184,14 @@ object Helpers {
     val propertyDefaultValueCases = properties.collect {
       case property if property.hasDefault =>
         s"""case "${property.name}" => $propertyDefaultsPath.${property.className}"""
-    }.mkString("\n|    ")
+    }.mkString(lineSeparator)
 
-    s"""
-       |  override def propertyDefaultValue(propertyKey: String) =
-       |    propertyKey match {
-       |      $propertyDefaultValueCases
-       |      case _ => super.propertyDefaultValue(propertyKey)
-       |  }
-       |""".stripMargin.replaceAll("\n", "\n  ")
+    s"""override def propertyDefaultValue(propertyKey: String) =
+       |  propertyKey match {
+       |    $propertyDefaultValueCases
+       |    case _ => super.propertyDefaultValue(propertyKey)
+       |}
+       |""".stripMargin
   }
 
   def propertyDefaultCases(properties: Seq[Property[_]]): String =

--- a/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -64,11 +64,11 @@ object Helpers {
     }
   }
 
-  def docAnnotationMaybe(customStepDoc: Option[String], indent: String = ""): String = {
+  def docAnnotationMaybe(customStepDoc: Option[String]): String = {
     customStepDoc.map(escapeJava) match {
       case Some(doc) =>
-        s"""$indent/** $doc */
-           |$indent@overflowdb.traversal.help.Doc(info = \"\"\"$doc\"\"\")""".stripMargin
+        s"""/** $doc */
+           |@overflowdb.traversal.help.Doc(info = \"\"\"$doc\"\"\")""".stripMargin
       case None => ""
     }
   }

--- a/sbt-overflowdb/build.sbt
+++ b/sbt-overflowdb/build.sbt
@@ -3,4 +3,6 @@ name := "sbt-overflowdb"
 scalaVersion := "2.12.14"
 dependsOn(Projects.codegen_2_12)
 
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+
 enablePlugins(SbtPlugin)


### PR DESCRIPTION
* reuses `scalafmtConfig` setting, i.e. code will be formatted just like the rest of the build
* can be disabled with `Compile / generateDomainClasses / disableFormatting := true`
* cleanup in codegen: remove lot's of manual indentation, which mostly went wrong anyway