### PR TITLE
add marker trait to AbstractNode

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -399,7 +399,7 @@ class CodeGen(schema: Schema) {
          |}
          |
          |/** Abstract supertype for overflowdb.Node and NewNode */
-         |trait AbstractNode {
+         |trait AbstractNode extends overflowdb.NodeOrDetachedNode {
          |  def label: String
          |}
          |


### PR DESCRIPTION
I forgot to include the marker trait in https://github.com/ShiftLeftSecurity/overflowdb-codegen/pull/154 :facepalm: 