### PR TITLE
Make `graph` a method.

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -130,7 +130,8 @@ class CodeGen(schema: Schema) {
          |  * Domain-specific wrapper for graph, starting point for traversals.
          |  * @param graph the underlying graph. An empty graph is created if this parameter is omitted.
          |  */
-         |class $domainShortName(val graph: Graph = $domainShortName.emptyGraph) extends AutoCloseable {
+         |class $domainShortName(private val _graph: Graph = $domainShortName.emptyGraph) extends AutoCloseable {
+         |  def graph: Graph = _graph
          |
          |  def help(implicit searchPackageNames: DocSearchPackages): String =
          |    new TraversalHelp(searchPackageNames).forTraversalSources


### PR DESCRIPTION
This enables us to create derived CPG classes which populate `graph`
lazy. Why do we need this? Well this enables us to create test fixtures
where the builder and the cpg are the same object.
E.g.:
val cpg = code("some code").moreCode("more code")
cpg.typeDecl.l

This becomes valuable in the scalatest setup we often times use where
the cpg in a `should` block is only supposed to be created only if the
test is actually executed (the cpg is accessed).