### PR TITLE
cache generated integrationtest domain classes

### DIFF
--- a/integration-tests/schemas/src/main/scala/TestSchema01.scala
+++ b/integration-tests/schemas/src/main/scala/TestSchema01.scala
@@ -35,6 +35,11 @@ class TestSchema01 extends TestSchema {
         |line 3
         |""".stripMargin)
 
+  node2.addContainedNode(
+    node = builder.anyNode,
+    localName = "containedAnyNode",
+    cardinality = Property.Cardinality.ZeroOrOne)
+
   val edge1 = builder.addEdgeType(
     name = "EDGE1",
     comment = "sample edge 1")


### PR DESCRIPTION
invalidate cache based on the codegen source, test schemas and (this)
build.sbt

also: add an (already green) test to ensure inner node is of type StoredNode