### PR TITLE
bring in `AnyNodeType` as a proper type and concept in codegen.schema

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -125,9 +125,13 @@ object Helpers {
     getCompleteType(property.cardinality, typeFor(property))
 
   def typeFor(containedNode: ContainedNode): String = {
-    val className = containedNode.nodeType.className
-    if (DefaultNodeTypes.AllClassNames.contains(className)) className
-    else className + "Base"
+    if (containedNode.nodeType == AnyNodeType) {
+      "AbstractNode"
+    } else {
+      val className = containedNode.nodeType.className
+      if (DefaultNodeTypes.AllClassNames.contains(className)) className
+      else className + "Base"
+    }
   }
 
   def getCompleteType(containedNode: ContainedNode): String =

--- a/codegen/src/main/scala/overflowdb/schema/Schema.scala
+++ b/codegen/src/main/scala/overflowdb/schema/Schema.scala
@@ -146,6 +146,15 @@ class NodeType(name: String, comment: Option[String], schemaInfo: SchemaInfo)
   override def toString = s"NodeType($name)"
 }
 
+/** root node trait for all nodes - use if you want to be explicitly unspecific */
+object AnyNodeType extends AbstractNodeType(
+  name = "AnyNode",
+  comment = Some("generic node base trait - use if you want to be explicitly unspecific"),
+  SchemaInfo.Unknown) {
+  /** all node types extend this node */
+  override def subtypes(allNodes: Set[AbstractNodeType]): Set[AbstractNodeType] = allNodes
+}
+
 class NodeBaseType(name: String, comment: Option[String], schemaInfo: SchemaInfo)
   extends AbstractNodeType(name, comment, schemaInfo) {
 
@@ -165,7 +174,11 @@ case class AdjacentNode(viaEdge: EdgeType, neighbor: AbstractNodeType, cardinali
 case class ContainedNode(nodeType: AbstractNodeType,
                          localName: String,
                          cardinality: Property.Cardinality,
-                         comment: Option[String])
+                         comment: Option[String]) {
+  lazy val classNameForStoredNode =
+    if (nodeType == AnyNodeType) "StoredNode"
+    else nodeType.className
+}
 
 /** An empty trait without any implementation, e.g. to mark a semantic relationship between certain types */
 case class MarkerTrait(name: String)

--- a/codegen/src/main/scala/overflowdb/schema/SchemaBuilder.scala
+++ b/codegen/src/main/scala/overflowdb/schema/SchemaBuilder.scala
@@ -1,6 +1,5 @@
 package overflowdb.schema
 
-import overflowdb.codegen.DefaultNodeTypes
 import overflowdb.codegen.Helpers._
 import overflowdb.schema.Property.ValueType
 
@@ -17,24 +16,8 @@ class SchemaBuilder(domainShortName: String,
   var protoOptions: Option[ProtoOptions] = None
   val noWarnList: mutable.Set[(AbstractNodeType, Property[_])] = mutable.Set.empty
 
-  /** root node trait for all nodes - use if you want to be explicitly unspecific
-    * n.b. 1: this one allows for StoredNode and NewNode
-    * n.b. 2: this it's not even part of the regular base types, but instead defined in the RootTypes.scala */
-  lazy val anyNode: NodeBaseType =
-    new NodeBaseType(
-      DefaultNodeTypes.AbstractNodeName,
-      Some("generic node base trait - use if you want to be explicitly unspecific"),
-      SchemaInfo.forClass(getClass)
-    )
-
-  /** root node trait for all stored nodes - use if you want to be explicitly unspecific
-    * n.b.: this it's not even part of the regular base types, but instead defined in the RootTypes.scala */
-  lazy val storedNode: NodeBaseType =
-    new NodeBaseType(
-      DefaultNodeTypes.StoredNodeName,
-      Some("generic stored node base trait - use if you want to be explicitly unspecific"),
-      SchemaInfo.forClass(getClass)
-    )
+  /** root node trait for all nodes - use if you want to be explicitly unspecific */
+  lazy val anyNode: AnyNodeType.type = AnyNodeType
 
   def addProperty[A](name: String, valueType: ValueType[A], comment: String = "")(
     implicit schemaInfo: SchemaInfo = SchemaInfo.Unknown): Property[A] = {

--- a/integration-tests/tests/src/test/scala/Schema01Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema01Test.scala
@@ -86,6 +86,7 @@ class Schema01Test extends AnyWordSpec with Matchers {
       val newNode2 = NewNode2()
         .name("name1")
         .node3(node3)
+        .containedAnyNode(node3) // contained node typed as `anyNode`
         .options(Seq("one", "two", "three"))
         .placements(Seq(1,2,3): Seq[Integer])
 
@@ -94,9 +95,11 @@ class Schema01Test extends AnyWordSpec with Matchers {
       BatchedUpdate.applyDiff(graph, builder)
 
       val node2 = node2Traversal.name("name1").head
+      // ensure contained nodes have the correct types - they should both be StoredNodes
       val innerNode: Option[Node3] = node2.node3
-      // ensure inner node is of type StoredNode
-      val innerNodeIsStoredNode: StoredNode = innerNode.get
+      val innerNodeGeneric: Option[StoredNode] = node2.containedAnyNode
+      innerNode.get shouldBe node3
+      innerNodeGeneric.get shouldBe node3
     }
   }
 


### PR DESCRIPTION
Driven by the need for having the result type `StoredNode` whenever
`anyNode` is used as a contained node inside another `StoredNode` -
see the newly added test

Generated code for TestSchema01:
```
// old generated code:
class Node2(graph: Graph, id: Long) ... {
  def containedAnyNode: Option[AbstractNode] = get().containedAnyNode
}

// new: 
class Node2(graph: Graph, id: Long) ... {
  def containedAnyNode: Option[StoredNode] = get().containedAnyNode
}

```