### PR TITLE
property setters for NewNodes

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -561,6 +561,12 @@ class CodeGen(schema: Schema) {
            |}""".stripMargin
       }
 
+      val newNodePropertySetters = nodeBaseType.properties.map { property =>
+        val camelCaseName = camelCase(property.name)
+        val tpe = getCompleteType(property)
+        s"def ${camelCaseName}_=(value: $tpe): Unit"
+      }.mkString(lineSeparator)
+
       s"""package $nodesPackage
          |
          |$companionObject
@@ -570,8 +576,9 @@ class CodeGen(schema: Schema) {
          |$mixinsForBaseTypes2
          |$mixinsForMarkerTraits
          |
-         |trait ${className}New extends NewNode
-         |$mixinForBaseTypesNew
+         |trait ${className}New extends NewNode $mixinForBaseTypesNew $mixinsForPropertyAccessorsReadOnly {
+         |  $newNodePropertySetters
+         |}
          |
          |trait $className extends StoredNode with ${className}Base
          |$mixinsForBaseTypes {

--- a/integration-tests/tests/src/test/scala/Schema02Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema02Test.scala
@@ -63,10 +63,11 @@ class Schema02Test extends AnyWordSpec with Matchers {
 
     "copied and mutated when upcasted" in {
       val original = NewNode1().name("A").order(1)
-      val upcasted = original.asInstanceOf[NewNode with HasName]
-      upcasted.name shouldBe "A"
+      val upcasted: BaseNodeNew = original
+
       val upcastedCopy = upcasted.copy
-      upcastedCopy.name shouldBe "A"
+      upcastedCopy.name = "C"
+      upcastedCopy.name shouldBe "C"
     }
 
     "be used as a Product" in {


### PR DESCRIPTION
https://github.com/ShiftLeftSecurity/overflowdb-codegen/pull/171 dropped
the property based mutable traits. That went a bit too far though - we
still need the setters, albait not as mixin traits...