### PR TITLE
replace property based mixins with node-specific property accessors

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -192,11 +192,20 @@ object Helpers {
        |""".stripMargin
   }
 
-  def propertyDefaultCases(properties: Seq[Property[_]]): String =
+  def propertyDefaultCases(properties: Seq[Property[_]]): String = {
     properties.collect {
       case p if p.hasDefault =>
         s"""val ${p.className} = ${defaultValueImpl(p.default.get)}"""
-    }.mkString("\n|    ")
+    }.mkString(s"$lineSeparator|    ")
+  }
+
+  def propertyAccessors(properties: Seq[Property[_]]): String = {
+    properties.map { property =>
+      val camelCaseName = camelCase(property.name)
+      val tpe = getCompleteType(property)
+      s"def $camelCaseName: $tpe"
+    }.mkString(lineSeparator)
+  }
 
   val propertyErrorRegisterImpl =
     s"""object PropertyErrorRegister {


### PR DESCRIPTION
Defining properties globally was a non-optimal decision.
Cardinality and comment are specific to the node where they're used.
There's a few areas where properties are reused with completely different semantics, e.g. fullName.
Even the name and type don't necessarily correlate, i.e. we get into trouble if we introduce a property with a different cardinality or type that has the same name.