### PR TITLE
implicits: bring in overflowdb.traversal.Implicits automatically

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1198,7 +1198,7 @@ class CodeGen(schema: Schema) {
          |}
          |
          |// lower priority implicits for base types
-         |trait NodeBaseTypeTraversalImplicits {
+         |trait NodeBaseTypeTraversalImplicits extends overflowdb.traversal.Implicits {
          |  $implicitsForNodeBaseTypeTraversals
          |}
          |""".stripMargin

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1207,7 +1207,7 @@ class CodeGen(schema: Schema) {
     def generateCustomStepNameTraversals(nodeType: AbstractNodeType): Seq[String] = {
       for {
         direction <- Seq(Direction.IN, Direction.OUT)
-        AdjacentNode(viaEdge, neighbor, cardinality, Some(customStepName), customStepDoc) <- nodeType.edges(direction).sortBy(_.customStepName)
+        case AdjacentNode(viaEdge, neighbor, cardinality, Some(customStepName), customStepDoc) <- nodeType.edges(direction).sortBy(_.customStepName)
       } yield {
         val mapOrFlatMap = cardinality match {
           case Cardinality.One => "map"

--- a/integration-tests/tests/src/test/scala/Schema01Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema01Test.scala
@@ -1,7 +1,6 @@
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.{BatchedUpdate, Config, Graph}
-import overflowdb.traversal._
 import testschema01._
 import testschema01.nodes._
 import testschema01.edges._

--- a/integration-tests/tests/src/test/scala/Schema02Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema02Test.scala
@@ -1,7 +1,7 @@
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.SchemaViolationException
-import overflowdb.traversal._
+import overflowdb.traversal.Traversal
 import testschema02._
 import testschema02.edges._
 import testschema02.nodes._

--- a/integration-tests/tests/src/test/scala/Schema04Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema04Test.scala
@@ -1,6 +1,5 @@
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import overflowdb.traversal._
 import overflowdb.Graph
 import testschema04._
 import testschema04.edges._

--- a/integration-tests/tests/src/test/scala/Schema05Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema05Test.scala
@@ -1,6 +1,5 @@
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import overflowdb.traversal._
 import overflowdb.{Config, Graph}
 import testschema05._
 import testschema05.edges._

--- a/integration-tests/tests/src/test/scala/Schema06Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema06Test.scala
@@ -1,7 +1,6 @@
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.{BatchedUpdate, Config, Graph}
-import overflowdb.traversal._
 import testschema06._
 import testschema06.nodes._
 import testschema06.edges._

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,10 +2,10 @@ import sbt._
 import com.lucidchart.sbtcross.BaseProject
 
 object Versions {
-  val overflowdb = "1.143"
+  val overflowdb = "1.151"
   val scala_2_12 = "2.12.16"
   val scala_2_13 = "2.13.8"
-  val scala_3 = "3.1.3"
+  val scala_3 = "3.2.1"
 }
 
 object Projects {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.7.2


### PR DESCRIPTION
implicit scope resolution was changes in scala3, hence extracting implicits for later reuse
https://docs.scala-lang.org/scala3/reference/changed-features/implicit-resolution.html

depends on https://github.com/ShiftLeftSecurity/overflowdb/pull/336