### PR TITLE
work around scala bug 4762

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -955,7 +955,7 @@ class CodeGen(schema: Schema) {
 
         val propertyDefaultValues = propertyDefaultValueImpl(s"$className.PropertyDefaults", properties)
 
-        s"""class $className(graph_4762: Graph, id_4762: Long /*cf wtflol https://github.com/scala/bug/issues/4762 */) extends NodeRef[$classNameDb](graph_4762, id_4762)
+        s"""class $className(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug/issues/4762 */) extends NodeRef[$classNameDb](graph_4762, id_4762)
            |  with ${className}Base
            |  with StoredNode
            |  $mixinsForExtendedNodes {
@@ -963,6 +963,16 @@ class CodeGen(schema: Schema) {
            |  $propertyDefaultValues
            |  $delegatingContainedNodeAccessors
            |    $neighborAccessorDelegators
+           |  // In view of https://github.com/scala/bug/issues/4762 it is advisable to use different variable names in
+           |  // patterns like `class Base(x:Int)` and `class Derived(x:Int) extends Base(x)`.
+           |  // This must become `class Derived(x_4762:Int) extends Base(x_4762)`.
+           |  // Otherwise, it is very hard to figure out whether uses of the identifier `x` refer to the base class x
+           |  // or the derived class x.
+           |  // When using that pattern, the class parameter `x_47672` should only be used in the `extends Base(x_4762)`
+           |  // clause and nowhere else. Otherwise, the compiler may well decide that this is not just a constructor
+           |  // parameter but also a field of the class, and we end up with two `x` fields. At best, this wastes memory;
+           |  // at worst both fields go out-of-sync for hard-to-debug correctness bugs.
+           |
            |
            |    override def fromNewNode(newNode: NewNode, mapping: NewNode => StoredNode): Unit = get().fromNewNode(newNode, mapping)
            |    override def canEqual(that: Any): Boolean = get.canEqual(that)

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -955,7 +955,7 @@ class CodeGen(schema: Schema) {
 
         val propertyDefaultValues = propertyDefaultValueImpl(s"$className.PropertyDefaults", properties)
 
-        s"""class $className(graph: Graph, id: Long) extends NodeRef[$classNameDb](graph, id)
+        s"""class $className(graph_4762: Graph, id_4762: Long /*cf wtflol https://github.com/scala/bug/issues/4762 */) extends NodeRef[$classNameDb](graph_4762, id_4762)
            |  with ${className}Base
            |  with StoredNode
            |  $mixinsForExtendedNodes {

--- a/integration-tests/tests/src/test/scala/Schema01Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema01Test.scala
@@ -97,5 +97,8 @@ class Schema01Test extends AnyWordSpec with Matchers {
       innerNode.get shouldBe node3
     }
   }
+  "work around scala bug 4762, ie generate no extraneous fields" in {
+    Class.forName("testschema01.nodes.Node1").getDeclaredFields.length shouldBe 0
+  }
 
 }


### PR DESCRIPTION
cf https://github.com/scala/bug/issues/4762 and the benchmarks in https://github.com/ShiftLeftSecurity/overflowdbv2/pull/11

Generally, I think we need a custom linter rule that forbids this kind of shadowing of superclass fields. 

Indeed, my preferred solution to 4762 would be to forbid the compiler from ever silently generating fields from class parameters in non-anonymous classes (i.e. outside of closures).

In other words, `class foo(x:Int){def getX:Int = x}` would become a warning and would demand a rewrite to `class foo(private val x:Int) {def getX:Int = x}`.

The general idea of "muh muh the compiler will figure out what fields you need" is imo a braindead stupid decision by the scala language. The single most important fact of a data type, i.e. non-singleton class, is its memory layout, and making it non-trivial to predict the set of fields from a class definition is just painful. Non-triviality is evidenced by the fact that we have wasted 8 bytes per node for god knows how long.

In this specific case, I think the issue is that the read of `id` in `def product` refers to the scala class parameter, while all other ones refer to the base class `id` field. Hence, the derived (duplicate) id field needs to be kept around for `def product`. Now both are final; so I can't tell whether the scala compiler is too stupid/buggy to figure out that only one is needed, or whether it is defensive enough to accommodate cases where people use reflection to modify a final field, or whether it needs to be that defensive to accommodate binary compat (i.e. runtime version of baseclass `NodeRef` differs from compile time version).