### PR TITLE
forbid positional arguments in NewNode constructor

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1661,7 +1661,7 @@ class CodeGen(schema: Schema) {
           }
           s"var $name: $fullType = $defaultValue"
 
-      }.mkString(", ")
+      }.mkString("\n")
 
       val propertiesMapImpl = {
         val putKeysImpl = properties
@@ -1761,10 +1761,11 @@ class CodeGen(schema: Schema) {
          |  def apply(): $classNameNewNode = new $classNameNewNode
          |}
          |
-         |class $classNameNewNode private ($memberVariables)
+         |class $classNameNewNode
          |  extends NewNode with ${nodeClassName}Base $mixins {
-         | // the constructor must be private, because argument positions are unstable (e.g. if we extend the schema)
          |  type StoredType = $nodeClassName
+         |
+         |  $memberVariables
          |
          |  override def label: String = "${nodeType.name}"
          |

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1761,9 +1761,9 @@ class CodeGen(schema: Schema) {
          |  def apply(): $classNameNewNode = new $classNameNewNode
          |}
          |
-         |class $classNameNewNode($memberVariables)
+         |class $classNameNewNode private ($memberVariables)
          |  extends NewNode with ${nodeClassName}Base $mixins {
-         |
+         | // the constructor must be private, because argument positions are unstable (e.g. if we extend the schema)
          |  type StoredType = $nodeClassName
          |
          |  override def label: String = "${nodeType.name}"


### PR DESCRIPTION
The order of positional arguments in the NewNode constructor is not stable under changes in the schema. Hence it must not be exposed to users.

The first commit achieved that by making the constructor private. The second (current) commit achieves the same by removing all arguments from the constructor. Hence code like `val c = new NewCall` still works, not just the preferred `val c = NewCall()`.

The construct `val c = new NewCall("what field am I initializing today?")` is forbidden either way.

This PR has the potential to break some code. That's a feature, not a bug.