### PR TITLE
Misc updates

### DIFF
--- a/codegen/src/main/scala/overflowdb/schema/Schema.scala
+++ b/codegen/src/main/scala/overflowdb/schema/Schema.scala
@@ -49,6 +49,9 @@ abstract class AbstractNodeType(val name: String, val comment: Option[String], v
   /** all node types that extend this node */
   def subtypes(allNodes: Set[AbstractNodeType]): Set[AbstractNodeType]
 
+  /** the name for the generated node starter. Generatiion of starters can be suppressed by setting to None, or custom
+   * names can be assigned to prevent compile errors for e.g. `type`*/
+  var starterName: Option[String] = Some(camelCase(name))
 
   /** properties (including potentially inherited properties) */
   override def properties: Seq[Property[_]] = {


### PR DESCRIPTION
Add generated schema-aware diffgraphbuilder. This will be necessary for odbv2. This change is fully compatible; in order to make use of it, we just need to change some (few) imports.

Add marker trait StaticType[+T] to AbstractNode, for ad-hoc subtyping. This change is fully compatible; we can make use of it to revamp OperatorExtensions in joern.

Generate nodestarters. We can use that to ensure that we have a full suite of nodestarters; furthermore this allows us to simplify future integration work on odbv2. This is 99% compatible: the new `starterName` property is needed to override some cases where we would otherwise get compile errors due to nameclashes with reserved keywords (e.g. `return` -> `ret`).

Downstream PRs will be linked.