### PR TITLE
require to specify output dir when the plugin is used

### DIFF
--- a/sbt-overflowdb/src/main/scala/overflowdb/codegen/sbt/CodegenSbtPlugin.scala
+++ b/sbt-overflowdb/src/main/scala/overflowdb/codegen/sbt/CodegenSbtPlugin.scala
@@ -36,9 +36,9 @@ object CodegenSbtPlugin extends AutoPlugin {
 
   lazy val generateDomainClassesTask =
     Def.taskDyn {
-      val classWithSchema_ = (generateDomainClasses/classWithSchema).value
-      val fieldName_ = (generateDomainClasses/fieldName).value
-      val outputDir_ = (generateDomainClasses/outputDir).value
+      val classWithSchemaValue = (generateDomainClasses/classWithSchema).value
+      val fieldNameValue = (generateDomainClasses/fieldName).value
+      val outputDirValue = (generateDomainClasses/outputDir).value
 
       val disableFormattingParamMaybe =
         if ((generateDomainClasses/disableFormatting).value) "--noformat"
@@ -58,19 +58,19 @@ object CodegenSbtPlugin extends AutoPlugin {
       lazy val lastSchemaAndDependenciesHash: Option[String] =
         Try(IO.read(schemaAndDependenciesHashFile)).toOption
 
-      if (outputDir_.exists && lastSchemaAndDependenciesHash == Some(currentSchemaAndDependenciesHash)) {
+      if (outputDirValue.exists && lastSchemaAndDependenciesHash == Some(currentSchemaAndDependenciesHash)) {
         // inputs did not change, don't regenerate
         Def.task {
-          FileUtils.listFilesRecursively(outputDir_)
+          FileUtils.listFilesRecursively(outputDirValue)
         }
       } else {
         Def.task {
-          FileUtils.deleteRecursively(outputDir_)
+          FileUtils.deleteRecursively(outputDirValue)
           (Compile/runMain).toTask(
-            s" overflowdb.codegen.Main --classWithSchema=$classWithSchema_ --field=$fieldName_ --out=$outputDir_ $disableFormattingParamMaybe $scalafmtConfigFileMaybe"
+            s" overflowdb.codegen.Main --classWithSchema=$classWithSchemaValue --field=$fieldNameValue --out=$outputDirValue $disableFormattingParamMaybe $scalafmtConfigFileMaybe"
           ).value
           IO.write(schemaAndDependenciesHashFile, currentSchemaAndDependenciesHash)
-          FileUtils.listFilesRecursively(outputDir_)
+          FileUtils.listFilesRecursively(outputDirValue)
         }
       }
     }

--- a/sbt-overflowdb/src/main/scala/overflowdb/codegen/sbt/CodegenSbtPlugin.scala
+++ b/sbt-overflowdb/src/main/scala/overflowdb/codegen/sbt/CodegenSbtPlugin.scala
@@ -19,8 +19,6 @@ object CodegenSbtPlugin extends AutoPlugin {
 
     lazy val baseSettings: Seq[Def.Setting[_]] = Seq(
       generateDomainClasses := generateDomainClassesTask.value,
-      generateDomainClasses/classWithSchema := "undefined",
-      generateDomainClasses/fieldName := "undefined",
       generateDomainClasses/disableFormatting := false,
     )
   }
@@ -28,8 +26,8 @@ object CodegenSbtPlugin extends AutoPlugin {
 
   override def requires = JvmPlugin && ScalafmtPlugin
 
-  // This plugin is automatically enabled for projects which are JvmPlugin.
-  override def trigger = allRequirements
+  // This plugin needs to be enabled manually via `enablePlugins`
+  override def trigger = noTrigger
 
   // a group of settings that are automatically added to projects.
   override val projectSettings = inConfig(Compile)(autoImport.baseSettings)
@@ -39,6 +37,7 @@ object CodegenSbtPlugin extends AutoPlugin {
       val classWithSchemaValue = (generateDomainClasses/classWithSchema).value
       val fieldNameValue = (generateDomainClasses/fieldName).value
       val outputDirValue = (generateDomainClasses/outputDir).value
+      assert(outputDirValue != null, "`generateDomainClasses/outputDir` is not defined, please configure it in your build definition, e.g. `generateDomainClasses/outputDir := (Projects.domainClasses/scalaSource).value`")
 
       val disableFormattingParamMaybe =
         if ((generateDomainClasses/disableFormatting).value) "--noformat"

--- a/sbt-overflowdb/src/main/scala/overflowdb/codegen/sbt/OdbCodegenSbtPlugin.scala
+++ b/sbt-overflowdb/src/main/scala/overflowdb/codegen/sbt/OdbCodegenSbtPlugin.scala
@@ -8,7 +8,7 @@ import sbt.Keys._
 
 import scala.util.Try
 
-object CodegenSbtPlugin extends AutoPlugin {
+object OdbCodegenSbtPlugin extends AutoPlugin {
 
   object autoImport {
     val generateDomainClasses = taskKey[Seq[File]]("generate overflowdb domain classes for our schema")

--- a/sbt-overflowdb/src/main/scala/overflowdb/codegen/sbt/OdbCodegenSbtPlugin.scala
+++ b/sbt-overflowdb/src/main/scala/overflowdb/codegen/sbt/OdbCodegenSbtPlugin.scala
@@ -11,7 +11,7 @@ import scala.util.Try
 object OdbCodegenSbtPlugin extends AutoPlugin {
 
   object autoImport {
-    val generateDomainClasses = taskKey[Seq[File]]("generate overflowdb domain classes for our schema")
+    val generateDomainClasses = taskKey[File]("generate overflowdb domain classes for the given schema - return value is the output root directory")
     val classWithSchema = settingKey[String]("class with schema field, e.g. `org.example.MyDomain$`")
     val fieldName = settingKey[String]("(static) field name for schema within the specified `classWithSchema` with schema field, e.g. `org.example.MyDomain$`")
     val disableFormatting = settingKey[Boolean]("disable scalafmt formatting")
@@ -58,7 +58,7 @@ object OdbCodegenSbtPlugin extends AutoPlugin {
       if (outputDirValue.exists && lastSchemaAndDependenciesHash == Some(currentSchemaAndDependenciesHash)) {
         // inputs did not change, don't regenerate
         Def.task {
-          FileUtils.listFilesRecursively(outputDirValue)
+          outputDirValue
         }
       } else {
         Def.task {
@@ -67,7 +67,7 @@ object OdbCodegenSbtPlugin extends AutoPlugin {
             s" overflowdb.codegen.Main --classWithSchema=$classWithSchemaValue --field=$fieldNameValue --out=$outputDirValue $disableFormattingParamMaybe $scalafmtConfigFileMaybe"
           ).value
           IO.write(schemaAndDependenciesHashFile, currentSchemaAndDependenciesHash)
-          FileUtils.listFilesRecursively(outputDirValue)
+          outputDirValue
         }
       }
     }

--- a/sbt-overflowdb/src/main/scala/overflowdb/codegen/sbt/OdbCodegenSbtPlugin.scala
+++ b/sbt-overflowdb/src/main/scala/overflowdb/codegen/sbt/OdbCodegenSbtPlugin.scala
@@ -12,6 +12,7 @@ object OdbCodegenSbtPlugin extends AutoPlugin {
 
   object autoImport {
     val generateDomainClasses = taskKey[File]("generate overflowdb domain classes for the given schema - return value is the output root directory")
+    val outputDir = settingKey[File]("target directory for the generated domain classes, e.g. `Projects.domainClasses/scalaSource`")
     val classWithSchema = settingKey[String]("class with schema field, e.g. `org.example.MyDomain$`")
     val fieldName = settingKey[String]("(static) field name for schema within the specified `classWithSchema` with schema field, e.g. `org.example.MyDomain$`")
     val disableFormatting = settingKey[Boolean]("disable scalafmt formatting")
@@ -35,7 +36,7 @@ object OdbCodegenSbtPlugin extends AutoPlugin {
     Def.taskDyn {
       val classWithSchemaValue = (generateDomainClasses/classWithSchema).value
       val fieldNameValue = (generateDomainClasses/fieldName).value
-      val outputDirValue = sourceManaged.value / "overflowdb-codegen"
+      val outputDirValue = (generateDomainClasses/outputDir).value
 
       val disableFormattingParamMaybe =
         if ((generateDomainClasses/disableFormatting).value) "--noformat"

--- a/sbt-overflowdb/src/main/scala/overflowdb/codegen/sbt/OdbCodegenSbtPlugin.scala
+++ b/sbt-overflowdb/src/main/scala/overflowdb/codegen/sbt/OdbCodegenSbtPlugin.scala
@@ -12,7 +12,6 @@ object OdbCodegenSbtPlugin extends AutoPlugin {
 
   object autoImport {
     val generateDomainClasses = taskKey[Seq[File]]("generate overflowdb domain classes for our schema")
-    val outputDir = settingKey[File]("target directory for the generated domain classes, e.g. `Projects.domainClasses/scalaSource`")
     val classWithSchema = settingKey[String]("class with schema field, e.g. `org.example.MyDomain$`")
     val fieldName = settingKey[String]("(static) field name for schema within the specified `classWithSchema` with schema field, e.g. `org.example.MyDomain$`")
     val disableFormatting = settingKey[Boolean]("disable scalafmt formatting")
@@ -36,8 +35,7 @@ object OdbCodegenSbtPlugin extends AutoPlugin {
     Def.taskDyn {
       val classWithSchemaValue = (generateDomainClasses/classWithSchema).value
       val fieldNameValue = (generateDomainClasses/fieldName).value
-      val outputDirValue = (generateDomainClasses/outputDir).value
-      assert(outputDirValue != null, "`generateDomainClasses/outputDir` is not defined, please configure it in your build definition, e.g. `generateDomainClasses/outputDir := (Projects.domainClasses/scalaSource).value`")
+      val outputDirValue = sourceManaged.value / "overflowdb-codegen"
 
       val disableFormattingParamMaybe =
         if ((generateDomainClasses/disableFormatting).value) "--noformat"


### PR DESCRIPTION
* allows us to use sbt's managed sources dirs, so we can check in the generated sources
* require to explicitly enable the plugin - otherwise it's enabled on all projects, that doesn't make sense
* refactor: naming convention