### PR TITLE
allow to disable codegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 [![Build Status](https://github.com/ShiftleftSecurity/overflowdb-codegen/workflows/release/badge.svg)](https://github.com/ShiftleftSecurity/overflowdb-codegen/actions?query=workflow%3Arelease)
 
 # overflowdb-codegen
+
+## Configuration overview: TODO
+
+## Disable temporarily
+You can temporarily disable the codegen in your build by setting the environment variable `ODB_CODEGEN_DISABLE=true`. That's useful e.g. if you made some manual changes to the generated files that would otherwise be overridden by the codegen. 

--- a/sbt-overflowdb/src/main/scala/overflowdb/codegen/sbt/OdbCodegenSbtPlugin.scala
+++ b/sbt-overflowdb/src/main/scala/overflowdb/codegen/sbt/OdbCodegenSbtPlugin.scala
@@ -56,11 +56,15 @@ object OdbCodegenSbtPlugin extends AutoPlugin {
       lazy val lastSchemaAndDependenciesHash: Option[String] =
         Try(IO.read(schemaAndDependenciesHashFile)).toOption
 
-      if (outputDirValue.exists && lastSchemaAndDependenciesHash == Some(currentSchemaAndDependenciesHash)) {
-        // inputs did not change, don't regenerate
+      val disabled = sys.env.getOrElse("ODB_CODEGEN_DISABLE", default = "false").toLowerCase == "true"
+      if (disabled) {
         Def.task {
+          streams.value.log.info("overflowdb codegen is disabled")
           outputDirValue
         }
+      } else if (outputDirValue.exists && lastSchemaAndDependenciesHash == Some(currentSchemaAndDependenciesHash)) {
+        // inputs did not change, don't regenerate
+        Def.task { outputDirValue }
       } else {
         Def.task {
           FileUtils.deleteRecursively(outputDirValue)


### PR DESCRIPTION
Useful e.g. if users want to modify the generated files and ensure
their changes are not being overridden by the codegen.