### PR TITLE
Bump odb, misc changes

### DIFF
--- a/codegen/src/main/scala/overflowdb/schema/Schema.scala
+++ b/codegen/src/main/scala/overflowdb/schema/Schema.scala
@@ -49,10 +49,14 @@ abstract class AbstractNodeType(val name: String, val comment: Option[String], v
   /** all node types that extend this node */
   def subtypes(allNodes: Set[AbstractNodeType]): Set[AbstractNodeType]
 
-  /** the name for the generated node starter. Generatiion of starters can be suppressed by setting to None, or custom
-   * names can be assigned to prevent compile errors for e.g. `type`*/
-  var starterName: Option[String] = Some(camelCase(name))
 
+  private var _starterName: Option[String] = Some(camelCase(name))
+
+  /** the name for the generated node starter. Custom names can be assigned to prevent compile errors for e.g. `type`.
+   * Generation of node-starter can be suppressed by passing null, or by calling `withoutStarter()`.*/
+  def starterName: Option[String] = _starterName
+  def starterName(name:String): this.type = {this._starterName = Option(name); this}
+  def withoutStarter(): this.type = starterName(null)
   /** properties (including potentially inherited properties) */
   override def properties: Seq[Property[_]] = {
     val entireClassHierarchy = this +: extendzRecursively

--- a/codegen/src/main/scala/overflowdb/schema/Schema.scala
+++ b/codegen/src/main/scala/overflowdb/schema/Schema.scala
@@ -49,6 +49,9 @@ abstract class AbstractNodeType(val name: String, val comment: Option[String], v
   /** all node types that extend this node */
   def subtypes(allNodes: Set[AbstractNodeType]): Set[AbstractNodeType]
 
+  /** the name for the generated node starter. Generatiion of starters can be suppressed by setting to None, or custom
+   * names can be assigned to prevent compile errors for e.g. `type`*/
+  var starterName: Option[String] = Some(camelCase(name))
 
   /** properties (including potentially inherited properties) */
   override def properties: Seq[Property[_]] = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,7 +2,7 @@ import sbt._
 import com.lucidchart.sbtcross.BaseProject
 
 object Versions {
-  val overflowdb = "1.174"
+  val overflowdb = "1.174+1-0e5788ca"
   val scala_2_12 = "2.12.17"
   val scala_2_13 = "2.13.10"
   val scala_3 = "3.2.2"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,7 +2,7 @@ import sbt._
 import com.lucidchart.sbtcross.BaseProject
 
 object Versions {
-  val overflowdb = "1.174+1-0e5788ca"
+  val overflowdb = "1.174+2-ded2b489"
   val scala_2_12 = "2.12.17"
   val scala_2_13 = "2.13.10"
   val scala_3 = "3.2.2"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,7 +2,7 @@ import sbt._
 import com.lucidchart.sbtcross.BaseProject
 
 object Versions {
-  val overflowdb = "1.174+2-ded2b489"
+  val overflowdb = "1.177"
   val scala_2_12 = "2.12.17"
   val scala_2_13 = "2.13.10"
   val scala_3 = "3.3.0"


### PR DESCRIPTION
This bumps odb, and adds the following other changes:
1. Also generate traversal variants of the `_astOut` steps.
2. Generate node starters. Their use is not mandatory -- this just starts generating them, and it will be our follow-up decision to use them in joern.
3. Generate a domain-specific DiffGraphBuilder.

(1) is upstream of https://github.com/joernio/joern/pull/2784

(2) and (3) are part of the same effort: Try to reduce the direct use of odb concepts in joern, so that the future migration effort with odbv2 will be much smaller. These changes are very compatible: The require no migration in joern, but they allow to start on it.