### PR TITLE
generate stable results - part x+1

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -661,7 +661,13 @@ class CodeGen(schema: Schema) {
             .map { case (edge, neighborContexts) =>
               val neighborInfoForNodes =
                 neighborContexts
-                  .sortBy(x => (x.adjacentNode.neighbor.name, x.adjacentNode.customStepName))
+                  .sortBy { x =>
+                    (x.adjacentNode.neighbor.name,
+                      x.adjacentNode.customStepName,
+                      x.adjacentNode.viaEdge.toString,
+                      x.adjacentNode.neighbor.name,
+                      x.adjacentNode.cardinality.toString)
+                  }
                   .map { case AjacentNodeWithInheritanceStatus(adjacentNode, isInherited) =>
                     NeighborInfoForNode(adjacentNode.neighbor, edge, direction, adjacentNode.cardinality, isInherited, adjacentNode.customStepName, adjacentNode.customStepDoc)
                   }

--- a/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/Helpers.scala
@@ -251,9 +251,11 @@ object Helpers {
       .orElse(findSharedRoot(neighborNodeInfos))
   }
 
-  /** in theory there can be multiple candidates - we're just returning one of those for now */
+  /** In theory there can be multiple candidates - we're just returning one of those for now.
+   * We want the results to be stable between different codegen runs, so we simply return the first
+   * in alphabetical order... */
   def lowestCommonAncestor(nodes: Set[AbstractNodeType]): Option[AbstractNodeType] = {
-    LowestCommonAncestors(nodes)(_.extendzRecursively.toSet).headOption
+    LowestCommonAncestors(nodes)(_.extendzRecursively.toSet).toSeq.sortBy(_.name).headOption
   }
 
   /** from the given node types, find one that is part of the complete type hierarchy of *all* other node types */

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.0
+sbt.version=1.9.2


### PR DESCRIPTION
* motivation: there were still a few unstable areas wrt the closed-source schema
* stable results for lowest common ancestor calculation
* better sorting for more stable generated code