### PR TITLE
Embed schema into `NewNode` object classes

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1698,6 +1698,8 @@ class CodeGen(schema: Schema) {
          |  override def getRefOrId(): Object = refOrId
          |  override def setRefOrId(r: Object): Unit = {this.refOrId = r}
          |  def stored: Option[StoredType] = if(refOrId != null && refOrId.isInstanceOf[StoredNode]) Some(refOrId).asInstanceOf[Option[StoredType]] else None
+         |  def isValidOutNeighbour(edgeLabel: String, n: NewNode): Boolean
+         |  def isValidInNeighbour(edgeLabel: String, n: NewNode): Boolean
          |}
          |""".stripMargin
 
@@ -1833,9 +1835,6 @@ class CodeGen(schema: Schema) {
          |  private val outNeighbours: Set[(String, String)] = Set(${outEdges.mkString(", ")})
          |  private val inNeighbours: Set[(String, String)] = Set(${inEdges.mkString(", ")})
          |
-         |  def isValidOutNeighbour(edgeLabel: String, n: NewNode): Boolean = outNeighbours.contains((edgeLabel, n.label))
-         |
-         |  def isValidInNeighbour(edgeLabel: String, n: NewNode): Boolean = inNeighbours.contains((edgeLabel, n.label))
          |}
          |
          |class $classNameNewNode
@@ -1855,6 +1854,14 @@ class CodeGen(schema: Schema) {
          |  $propertySettersImpl
          |
          |  $propertiesMapImpl
+         |
+         |  import $classNameNewNode.{outNeighbours, inNeighbours}
+         |
+         |  override def isValidOutNeighbour(edgeLabel: String, n: NewNode): Boolean =
+         |    outNeighbours.contains((edgeLabel, n.label))
+         |
+         |  override def isValidInNeighbour(edgeLabel: String, n: NewNode): Boolean =
+         |    inNeighbours.contains((edgeLabel, n.label))
          |
          |  override def productElement(n: Int): Any =
          |    n match {

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1682,6 +1682,18 @@ class CodeGen(schema: Schema) {
     results.toSeq
   }
 
+  /**
+   * Useful string extensions to avoid Scala version incompatible interpolations.
+   */
+  implicit class StringExt(s: String) {
+
+    def quote: String = {
+      val quote = "\""
+      new StringBuilder(s.length() + 2 * quote.length(), quote).append(s).append(quote).mkString
+    }
+
+  }
+
   /** generates classes to easily add new nodes to the graph
     * this ability could have been added to the existing nodes, but it turned out as a different specialisation,
     * since e.g. `id` is not set before adding it to the graph */
@@ -1887,8 +1899,8 @@ class CodeGen(schema: Schema) {
     if (outfile.exists) outfile.delete()
     outfile.createFile()
     val src = schema.nodeTypes.map { nodeType =>
-      val inEdges =  nodeType.inEdges.map(x => (s"\"${x.viaEdge.name}\"", s"\"${x.neighbor.name}\"")).toSet
-      val outEdges =  nodeType.outEdges.map(x => (s"\"${x.viaEdge.name}\"", s"\"${x.neighbor.name}\"")).toSet
+      val inEdges =  nodeType.inEdges.map(x => (x.viaEdge.name.quote, x.neighbor.name.quote)).toSet
+      val outEdges =  nodeType.outEdges.map(x => (x.viaEdge.name.quote, x.neighbor.name.quote)).toSet
       generateNewNodeSource(nodeType, nodeType.properties, inEdges, outEdges)
     }.mkString(lineSeparator)
     outfile.write(s"""$staticHeader

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1,8 +1,8 @@
 package overflowdb.codegen
 
-import better.files.*
+import better.files._
 import overflowdb.codegen.CodeGen.ConstantContext
-import overflowdb.schema.*
+import overflowdb.schema._
 import overflowdb.schema.EdgeType.Cardinality
 import overflowdb.schema.Property.ValueType
 
@@ -11,7 +11,7 @@ import scala.collection.mutable
 
 /** Generates a domain model for OverflowDb traversals for a given domain-specific schema. */
 class CodeGen(schema: Schema) {
-  import Helpers.*
+  import Helpers._
   val basePackage = schema.basePackage
   val nodesPackage = s"$basePackage.nodes"
   val edgesPackage = s"$basePackage.edges"

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1688,8 +1688,7 @@ class CodeGen(schema: Schema) {
   implicit class StringExt(s: String) {
 
     def quote: String = {
-      val quote = "\""
-      new StringBuilder(s.length() + 2 * quote.length(), quote).append(s).append(quote).mkString
+      s""""$s""""
     }
 
   }


### PR DESCRIPTION
The idea behind this change is to provide the option of allowing frontend developers to catch invalid edge types early on instead of when the `DiffGraph` is atomically merged into the graph.

Downstream, during development, we could have a validation flag on `X2Cpg` that would enable checks on `Ast` to validate neighbours as they are being set.