### PR TITLE
codegen: add some type aliases so that the domain-specific code can avoid referencing the `overflow` namespace

### DIFF
--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1270,7 +1270,6 @@ class CodeGen(schema: Schema) {
          |
          |package object $packageSimpleName {
          |  // some type aliases so that the domain-specific code can avoid referencing the `overflowdb` namespace
-         |  type DiffGraphBuilder = _root_.overflowdb.BatchedUpdate.DiffGraphBuilder
          |  
          |  object help {
          |    type Doc = _root_.overflowdb.traversal.help.Doc

--- a/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
+++ b/codegen/src/main/scala/overflowdb/codegen/CodeGen.scala
@@ -1259,6 +1259,29 @@ class CodeGen(schema: Schema) {
       val srcFile = nodeType.className + ".scala"
       results.append(baseDir.createChild(srcFile).write(src))
     }
+
+
+    val packageObject = {
+      val lastSeparatorIdx  = basePackage.lastIndexOf('.')
+      val packageParent     = basePackage.take(lastSeparatorIdx)
+      val packageSimpleName = basePackage.drop(lastSeparatorIdx + 1)
+
+      s"""package $packageParent
+         |
+         |package object $packageSimpleName {
+         |  // some type aliases so that the domain-specific code can avoid referencing the `overflowdb` namespace
+         |  type DiffGraphBuilder = _root_.overflowdb.BatchedUpdate.DiffGraphBuilder
+         |  
+         |  object help {
+         |    type Doc = _root_.overflowdb.traversal.help.Doc
+         |    type Traversal = _root_.overflowdb.traversal.help.Traversal
+         |    type TraversalSource = _root_.overflowdb.traversal.help.TraversalSource
+         |  }
+         |}
+         |""".stripMargin
+    }
+    results.append(baseDir.createChild("package.scala").write(packageObject))
+
     results.toSeq
   }
 

--- a/integration-tests/schemas/build.sbt
+++ b/integration-tests/schemas/build.sbt
@@ -19,7 +19,7 @@ generateDomainClasses := Def.taskDyn {
     }
   } else {
     Def.task {
-      val invoked = (Compile/runMain).toTask(s" CodegenForAllSchemas").value
+      val invoked = (Compile/runMain).toTask(s" overflowdb.integrationtests.CodegenForAllSchemas").value
       lastSchemaMd5(currentSchemaMd5)
       FileUtils.listFilesRecursively(outputRoot)
     }

--- a/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/CodegenForAllSchemas.scala
+++ b/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/CodegenForAllSchemas.scala
@@ -1,3 +1,5 @@
+package overflowdb.integrationtests
+
 import overflowdb.codegen.CodeGen
 
 import java.io.File

--- a/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/TestSchema.scala
+++ b/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/TestSchema.scala
@@ -1,3 +1,5 @@
+package overflowdb.integrationtests
+
 import overflowdb.schema.SchemaBuilder
 
 trait TestSchema {

--- a/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/TestSchema01.scala
+++ b/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/TestSchema01.scala
@@ -1,3 +1,5 @@
+package overflowdb.integrationtests
+
 import overflowdb.schema.Property.ValueType
 import overflowdb.schema._
 

--- a/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/TestSchema02.scala
+++ b/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/TestSchema02.scala
@@ -1,3 +1,5 @@
+package overflowdb.integrationtests
+
 import overflowdb.schema.Property.ValueType
 import overflowdb.schema._
 

--- a/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/TestSchema03.scala
+++ b/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/TestSchema03.scala
@@ -1,3 +1,5 @@
+package overflowdb.integrationtests
+
 /** complex scenario with multiple layers of base nodes
   * similar to what we use in docker-ext schema extension
   */

--- a/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/TestSchema04.scala
+++ b/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/TestSchema04.scala
@@ -1,3 +1,5 @@
+package overflowdb.integrationtests
+
 import overflowdb.schema.Property._
 
 /** For testing default values on properties with Cardinality.One: we have type-dependent defaults,

--- a/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/TestSchema05.scala
+++ b/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/TestSchema05.scala
@@ -1,3 +1,5 @@
+package overflowdb.integrationtests
+
 import overflowdb.schema.Property._
 
 /** testing all property types with Cardinality.ZeroOrOne */

--- a/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/TestSchema06.scala
+++ b/integration-tests/schemas/src/main/scala/overflowdb/integrationtests/TestSchema06.scala
@@ -1,3 +1,5 @@
+package overflowdb.integrationtests
+
 import overflowdb.schema.Property.ValueType
 import overflowdb.schema._
 

--- a/integration-tests/tests/src/test/scala/Schema01Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema01Test.scala
@@ -1,6 +1,7 @@
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.{BatchedUpdate, Config, Graph}
+import overflowdb.integrationtests.testschema01
 import testschema01._
 import testschema01.nodes._
 import testschema01.edges._
@@ -8,7 +9,7 @@ import testschema01.traversal._
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 class Schema01Test extends AnyWordSpec with Matchers {
-  import testschema01.traversal._
+  import overflowdb.integrationtests.testschema01.traversal._
   "constants" in {
     PropertyNames.NAME shouldBe "NAME"
     Properties.Order.name shouldBe "ORDER"
@@ -109,7 +110,7 @@ class Schema01Test extends AnyWordSpec with Matchers {
     }
   }
   "work around scala bug 4762, ie generate no extraneous fields" in {
-    Class.forName("testschema01.nodes.Node1").getDeclaredFields.length shouldBe 0
+    Class.forName("overflowdb.integrationtests.testschema01.nodes.Node1").getDeclaredFields.length shouldBe 0
   }
 
 }

--- a/integration-tests/tests/src/test/scala/Schema02Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema02Test.scala
@@ -1,6 +1,7 @@
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.SchemaViolationException
+import overflowdb.integrationtests.testschema02
 import testschema02._
 import testschema02.edges._
 import testschema02.nodes._

--- a/integration-tests/tests/src/test/scala/Schema03Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema03Test.scala
@@ -1,4 +1,7 @@
 import overflowdb.traversal._
+import overflowdb.integrationtests.testschema03a
+import overflowdb.integrationtests.testschema03b
+import overflowdb.integrationtests.testschema03c
 
 class Schema03aTest {
   import testschema03a._

--- a/integration-tests/tests/src/test/scala/Schema04Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema04Test.scala
@@ -1,6 +1,7 @@
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.Graph
+import overflowdb.integrationtests.testschema04
 import testschema04._
 import testschema04.edges._
 import testschema04.nodes._

--- a/integration-tests/tests/src/test/scala/Schema05Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema05Test.scala
@@ -1,6 +1,7 @@
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.{Config, Graph}
+import overflowdb.integrationtests.testschema05
 import testschema05._
 import testschema05.edges._
 import testschema05.nodes._

--- a/integration-tests/tests/src/test/scala/Schema06Test.scala
+++ b/integration-tests/tests/src/test/scala/Schema06Test.scala
@@ -1,6 +1,7 @@
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.{BatchedUpdate, Config, Graph}
+import overflowdb.integrationtests.testschema06
 import testschema06._
 import testschema06.nodes._
 import testschema06.edges._


### PR DESCRIPTION
equivalent of https://github.com/joernio/flatgraph/pull/217